### PR TITLE
Fix "headlamp goggles" bug on Pimax

### DIFF
--- a/GTFO_VR/Core/PlayerBehaviours/VRRendering.cs
+++ b/GTFO_VR/Core/PlayerBehaviours/VRRendering.cs
@@ -102,6 +102,7 @@ namespace GTFO_VR.Core.PlayerBehaviours
 
                 if (!ItemEquippableEvents.CurrentItemHasFlashlight())
                 {
+                    inv.m_flashlightCLight.m_unityLight.transform.forward = HMD.GetWorldForward();
                     inv.m_flashlightCLight.m_unityLight.transform.position = HMD.Hmd.transform.TransformPoint(m_fpsCamera.m_owner.Inventory.m_flashlightCameraOffset);
                 }
                 else


### PR DESCRIPTION
The lamp was pointing forward relative to each eye, causing it to show up in each eye with different directions due to Pimax's canted displays. It now points forward relative to the headset.