### PR TITLE
Fix terminal audio log prompt not responding to terminal keyboard input

### DIFF
--- a/GTFO_VR/Core/UI/Terminal/KeyboardDefinition/KeyDefinition.cs
+++ b/GTFO_VR/Core/UI/Terminal/KeyboardDefinition/KeyDefinition.cs
@@ -40,6 +40,7 @@ namespace GTFO_VR.Core.UI.Terminal.KeyboardDefinition
         public KeyType KeyType = KeyType.INPUT;
         public string Input;
         public string Label;
+        public KeyCode KeyCode = KeyCode.None;
         public LayoutParameters Parameters;
         public KeyboardStyle Style;
         public bool RepeatKey = false;
@@ -92,6 +93,17 @@ namespace GTFO_VR.Core.UI.Terminal.KeyboardDefinition
         {
             this.Appearance = apperance;
             return this;
+        }
+
+        public KeyDefinition SetKeycode( KeyCode key )
+        {
+            this.KeyCode = key;
+            return this;
+        }
+
+        public bool HasKeyCode()
+        {
+            return KeyCode != KeyCode.None;
         }
 
         public bool HasInput()

--- a/GTFO_VR/Core/UI/Terminal/TerminalKeyboardInterface.cs
+++ b/GTFO_VR/Core/UI/Terminal/TerminalKeyboardInterface.cs
@@ -37,6 +37,9 @@ namespace GTFO_VR.Core.UI.Terminal
         private static string m_currentFrameInput = "";
         private static string m_prevFrameInput = "";
 
+        private static KeyCode m_currentFrameKeycode = KeyCode.None;
+        private static KeyCode m_prevFrameKeycode = KeyCode.None;
+
         public static TerminalKeyboardInterface create()
         {
             GameObject go = new GameObject();
@@ -259,12 +262,18 @@ namespace GTFO_VR.Core.UI.Terminal
                     go.transform.localPosition += (-go.transform.forward) * 0.05f;
                     break;
             }
-            
         }
 
         [HideFromIl2Cpp]
         public void HandleInput( KeyDefinition key )
         {
+            // A keycode down does not result in text being added to the terminal, but is required for some single-key actions
+            // Always performing it, in addition to adding its input, seems to work fine.
+            if (key.HasKeyCode())
+            {
+                m_currentFrameKeycode = key.KeyCode;
+            }
+
             if (key.HasInput())
             {
                 m_currentFrameInput += key.Input;
@@ -319,11 +328,20 @@ namespace GTFO_VR.Core.UI.Terminal
             m_prevFrameInput = m_currentFrameInput;
             m_currentFrameInput = "";
 
+            m_prevFrameKeycode = m_currentFrameKeycode;
+            m_currentFrameKeycode = KeyCode.None;
+
         }
 
         public static string GetKeyboardInput()
         {
             return m_prevFrameInput;
+        }
+
+
+        public static bool GetKeycodeDown( KeyCode key )
+        {
+            return key == m_prevFrameKeycode;
         }
 
         public static bool HasKeyboardInput()
@@ -440,16 +458,16 @@ namespace GTFO_VR.Core.UI.Terminal
 
                 keyboardRow.AddChild(new KeyDefinition(KeyType.ESC, "x")
                     .SetApperance(KeyApperanceType.EXIT));
-                keyboardRow.AddChild(new KeyDefinition("1"));
-                keyboardRow.AddChild(new KeyDefinition("2"));
-                keyboardRow.AddChild(new KeyDefinition("3"));
-                keyboardRow.AddChild(new KeyDefinition("4"));
-                keyboardRow.AddChild(new KeyDefinition("5"));
-                keyboardRow.AddChild(new KeyDefinition("6"));
-                keyboardRow.AddChild(new KeyDefinition("7"));
-                keyboardRow.AddChild(new KeyDefinition("8"));
-                keyboardRow.AddChild(new KeyDefinition("9"));
-                keyboardRow.AddChild(new KeyDefinition("0"));
+                keyboardRow.AddChild(new KeyDefinition("1").SetKeycode(KeyCode.Alpha1));
+                keyboardRow.AddChild(new KeyDefinition("2").SetKeycode(KeyCode.Alpha2));
+                keyboardRow.AddChild(new KeyDefinition("3").SetKeycode(KeyCode.Alpha3));
+                keyboardRow.AddChild(new KeyDefinition("4").SetKeycode(KeyCode.Alpha4));
+                keyboardRow.AddChild(new KeyDefinition("5").SetKeycode(KeyCode.Alpha5));
+                keyboardRow.AddChild(new KeyDefinition("6").SetKeycode(KeyCode.Alpha6));
+                keyboardRow.AddChild(new KeyDefinition("7").SetKeycode(KeyCode.Alpha7));
+                keyboardRow.AddChild(new KeyDefinition("8").SetKeycode(KeyCode.Alpha8));
+                keyboardRow.AddChild(new KeyDefinition("9").SetKeycode(KeyCode.Alpha9));
+                keyboardRow.AddChild(new KeyDefinition("0").SetKeycode(KeyCode.Alpha0));
                 keyboardRow.AddChild(new KeyDefinition("."));   // For typing ip addresses
                 keyboardRow.AddChild(new KeyDefinition(KeyType.BACKPSPACE, "Backspace", new LayoutParameters( LayoutParameters.FILL_PARENT ))
                     .SetRepeatKey(true)
@@ -468,16 +486,16 @@ namespace GTFO_VR.Core.UI.Terminal
 
                     keyboardRow.AddChild(new KeyDefinition(KeyType.EMPTY, "", 1.5f) // Tab
                         .SetApperance(KeyApperanceType.ALT));
-                    keyboardRow.AddChild(new KeyDefinition("q"));
-                    keyboardRow.AddChild(new KeyDefinition("w"));
-                    keyboardRow.AddChild(new KeyDefinition("e"));
-                    keyboardRow.AddChild(new KeyDefinition("r"));
-                    keyboardRow.AddChild(new KeyDefinition("t"));
-                    keyboardRow.AddChild(new KeyDefinition("y"));
-                    keyboardRow.AddChild(new KeyDefinition("u"));
-                    keyboardRow.AddChild(new KeyDefinition("i"));
-                    keyboardRow.AddChild(new KeyDefinition("o"));
-                    keyboardRow.AddChild(new KeyDefinition("p"));
+                    keyboardRow.AddChild(new KeyDefinition("q").SetKeycode(KeyCode.Q));
+                    keyboardRow.AddChild(new KeyDefinition("w").SetKeycode(KeyCode.W));
+                    keyboardRow.AddChild(new KeyDefinition("e").SetKeycode(KeyCode.E));
+                    keyboardRow.AddChild(new KeyDefinition("r").SetKeycode(KeyCode.R));
+                    keyboardRow.AddChild(new KeyDefinition("t").SetKeycode(KeyCode.T));
+                    keyboardRow.AddChild(new KeyDefinition("y").SetKeycode(KeyCode.Y));
+                    keyboardRow.AddChild(new KeyDefinition("u").SetKeycode(KeyCode.U));
+                    keyboardRow.AddChild(new KeyDefinition("i").SetKeycode(KeyCode.I));
+                    keyboardRow.AddChild(new KeyDefinition("o").SetKeycode(KeyCode.O));
+                    keyboardRow.AddChild(new KeyDefinition("p").SetKeycode(KeyCode.P));
                     keyboardRow.AddChild(new KeyDefinition("-"));
 
                     shortRowVertical.AddChild(keyboardRow);
@@ -491,15 +509,15 @@ namespace GTFO_VR.Core.UI.Terminal
                         .SetApperance(KeyApperanceType.ALT));
                     keyboardRow.AddChild(new KeyDefinition(KeyType.EMPTY, "", 0.35f)
                     .SetApperance(KeyApperanceType.GONE));
-                    keyboardRow.AddChild(new KeyDefinition("a"));
-                    keyboardRow.AddChild(new KeyDefinition("s"));
-                    keyboardRow.AddChild(new KeyDefinition("d"));
-                    keyboardRow.AddChild(new KeyDefinition("f"));
-                    keyboardRow.AddChild(new KeyDefinition("g"));
-                    keyboardRow.AddChild(new KeyDefinition("h"));
-                    keyboardRow.AddChild(new KeyDefinition("j"));
-                    keyboardRow.AddChild(new KeyDefinition("k"));
-                    keyboardRow.AddChild(new KeyDefinition("l"));
+                    keyboardRow.AddChild(new KeyDefinition("a").SetKeycode(KeyCode.A));
+                    keyboardRow.AddChild(new KeyDefinition("s").SetKeycode(KeyCode.S));
+                    keyboardRow.AddChild(new KeyDefinition("d").SetKeycode(KeyCode.D));
+                    keyboardRow.AddChild(new KeyDefinition("f").SetKeycode(KeyCode.F));
+                    keyboardRow.AddChild(new KeyDefinition("g").SetKeycode(KeyCode.G));
+                    keyboardRow.AddChild(new KeyDefinition("h").SetKeycode(KeyCode.H));
+                    keyboardRow.AddChild(new KeyDefinition("j").SetKeycode(KeyCode.J));
+                    keyboardRow.AddChild(new KeyDefinition("k").SetKeycode(KeyCode.K));
+                    keyboardRow.AddChild(new KeyDefinition("l").SetKeycode(KeyCode.L));
                     keyboardRow.AddChild(new KeyDefinition("_"));
                     keyboardRow.AddChild(new KeyDefinition(KeyType.ENTER, "", new LayoutParameters(LayoutParameters.FILL_PARENT, 1, 0.01f))
                         .SetApperance(KeyApperanceType.GONE));
@@ -513,13 +531,13 @@ namespace GTFO_VR.Core.UI.Terminal
 
                     keyboardRow.AddChild(new KeyDefinition(KeyType.SHIFT, "", 2.4f)
                         .SetApperance(KeyApperanceType.ALT));
-                    keyboardRow.AddChild(new KeyDefinition("z"));
-                    keyboardRow.AddChild(new KeyDefinition("x"));
-                    keyboardRow.AddChild(new KeyDefinition("c"));
-                    keyboardRow.AddChild(new KeyDefinition("v"));
-                    keyboardRow.AddChild(new KeyDefinition("b"));
-                    keyboardRow.AddChild(new KeyDefinition("n"));
-                    keyboardRow.AddChild(new KeyDefinition("m"));
+                    keyboardRow.AddChild(new KeyDefinition("z").SetKeycode(KeyCode.Z));
+                    keyboardRow.AddChild(new KeyDefinition("x").SetKeycode(KeyCode.X));
+                    keyboardRow.AddChild(new KeyDefinition("c").SetKeycode(KeyCode.C));
+                    keyboardRow.AddChild(new KeyDefinition("v").SetKeycode(KeyCode.V));
+                    keyboardRow.AddChild(new KeyDefinition("b").SetKeycode(KeyCode.B));
+                    keyboardRow.AddChild(new KeyDefinition("n").SetKeycode(KeyCode.N));
+                    keyboardRow.AddChild(new KeyDefinition("m").SetKeycode(KeyCode.M));
                     keyboardRow.AddChild(new KeyDefinition(","));
                     keyboardRow.AddChild(new KeyDefinition("."));
                     keyboardRow.AddChild(new KeyDefinition(KeyType.UP, "^", 1.1f)

--- a/GTFO_VR/Core/UI/Terminal/TerminalKeyboardInterface.cs
+++ b/GTFO_VR/Core/UI/Terminal/TerminalKeyboardInterface.cs
@@ -34,7 +34,8 @@ namespace GTFO_VR.Core.UI.Terminal
         public static readonly int LAYER_MASK = 1 << LAYER;
         public static readonly float CANVAS_SCALE = 0.045f; // Same scaling used by GTFO, because otherwise units are silly.
 
-        private static string currentInput = "";
+        private static string m_currentFrameInput = "";
+        private static string m_prevFrameInput = "";
 
         public static TerminalKeyboardInterface create()
         {
@@ -266,7 +267,7 @@ namespace GTFO_VR.Core.UI.Terminal
         {
             if (key.HasInput())
             {
-                currentInput += key.Input;
+                m_currentFrameInput += key.Input;
             }
             else
             {
@@ -311,23 +312,29 @@ namespace GTFO_VR.Core.UI.Terminal
             }
         }
 
+        public void LateUpdate()
+        {
+            // We receive input during normal update, but it is read earlier.
+            // Make a copy of the input this frame, and serve it as input for the entirety of next frame.
+            m_prevFrameInput = m_currentFrameInput;
+            m_currentFrameInput = "";
+
+        }
+
         public static string GetKeyboardInput()
         {
-            // This is only called once, so we can just clear it here.
-            string retString = currentInput;
-            currentInput = "";
-            return retString;
+            return m_prevFrameInput;
         }
 
         public static bool HasKeyboardInput()
         {
-            return !String.IsNullOrEmpty(currentInput);
+            return !String.IsNullOrEmpty(m_prevFrameInput);
         }
 
         [HideFromIl2Cpp]
         public void HandleInput(string str)
         {
-            currentInput += str;
+            m_currentFrameInput += str;
         }
 
         [HideFromIl2Cpp]

--- a/GTFO_VR/GTFO_VR.csproj
+++ b/GTFO_VR/GTFO_VR.csproj
@@ -107,6 +107,7 @@
     <Compile Include="Injections\Events\InjectTentacleAttackEvents.cs" />
     <Compile Include="Injections\GameHooks\InjectPlayerGUIRef.cs" />
     <Compile Include="Injections\GameHooks\InjectVRStart.cs" />
+    <Compile Include="Injections\Input\InjectKeyInput.cs" />
     <Compile Include="Injections\Rendering\InjectClusteredRenderingResolutionTweak.cs" />
     <Compile Include="Injections\Rendering\InjectDisableFPSCameraRenderUpdate.cs" />
     <Compile Include="Injections\Rendering\InjectPostProcessTweaks.cs" />

--- a/GTFO_VR/Injections/Input/InjectKeyInput.cs
+++ b/GTFO_VR/Injections/Input/InjectKeyInput.cs
@@ -1,0 +1,24 @@
+﻿using GTFO_VR.Core;
+using GTFO_VR.Core.UI;
+using GTFO_VR.Core.UI.Terminal;
+using HarmonyLib;
+using UnityEngine;
+
+namespace GTFO_VR.Injections.Input
+{
+    /// <summary>
+    /// Handles rare occasions of GTFO checking input for a specific keycode.
+    /// Used when the terminal plays an audio log and requests Y / N input to play/cancel, and Z to stop.
+    /// </summary>
+    ///
+
+    [HarmonyPatch(typeof(UnityEngine.Input), nameof(UnityEngine.Input.GetKeyDown), typeof(UnityEngine.KeyCode))]
+    internal class InjectKeyDown
+    {
+        private static void Postfix(KeyCode key, ref bool __result)
+        {
+            __result = __result || TerminalKeyboardInterface.GetKeycodeDown(key);
+        }
+    }
+
+}


### PR DESCRIPTION
### What is this

This PR fixes the terminal not responding to single-key prompts from the terminal keyboard, such as when being asked to press Y or N when playing an audio log.

### What does it do

Unlike the existing terminal text input, the audio log prompt looks for a specific `KeyCode` using `UnityEngine.Input.GetKeyDown(KeyCode keycode)`, and is therefore not triggered.

This has been fixed by [patching `GetKeyDown()`](https://github.com/Nordskog/GTFO_VR_Plugin/blob/KeyboardAudioLogFix/GTFO_VR/Injections/Input/InjectKeyInput.cs) in the same way [`InjectInput`](https://github.com/Nordskog/GTFO_VR_Plugin/blob/KeyboardAudioLogFix/GTFO_VR/Injections/Input/InjectInput.cs) does for `GetActionDown()` and friends.

I am a bit unclear on when one should use a detour instead of a patch ( like how the rest of the terminal input is handled in `TerminalInputDetours` ), but from what I understand it is always preferable to use a patch if you can.

A `KeyDefinition` can now be assigned a `KeyCode`. All the letters and numbers have been [assigned their respective `KeyCodes`](https://github.com/Nordskog/GTFO_VR_Plugin/blob/KeyboardAudioLogFix/GTFO_VR/Core/UI/Terminal/TerminalKeyboardInterface.cs#L489).
When pressed, `TerminalKeyboardInterface` will store the KeyCode for one frame, and the new `GetKeyDown()` patch can query it via [`GetKeycodeDown()` ](https://github.com/Nordskog/GTFO_VR_Plugin/blob/KeyboardAudioLogFix/GTFO_VR/Core/UI/Terminal/TerminalKeyboardInterface.cs#L342)

This means we are both adding text to the input, and triggering a key down event, at the same time. Luckily this is fine, and does not result in duplicate input or anything.

For both the text input and the `KeyCode`, the value is now first temporarily stored until [`LateUpdate`](https://github.com/Nordskog/GTFO_VR_Plugin/blob/KeyboardAudioLogFix/GTFO_VR/Core/UI/Terminal/TerminalKeyboardInterface.cs#L324) and only then swapped into the variables queried by the patches and detours. This ensures that the value persists for a full frame, as it should.

There was one report of the keyboard buttons ( input only, not the exit/backspace/arrows that rely on actions instead ) suddenly not working in D1. Unable to reproduce but the previous clear-text-input-on-read approach may have been the cause, so this will hopefully fix that too.


### Notes

The terminal expects lower-case input, and always converts everything to upper-case before running comparisons, so we don't need to do that.

In addition to the easily accessible first terminal in CX with an audio log on it, I  have tested the first 2 terminals in A1 ( audio buffer overflow press any key to continue ), first terminal in D2, passworded terminal in BX and the outside, DX outside ( uplink puzzle ) and D1 ( reactor startup), and nothing exploded. 