### PR TITLE
Add basic support for Rundown 7

### DIFF
--- a/GTFO_VR/Core/PlayerBehaviours/VRRendering.cs
+++ b/GTFO_VR/Core/PlayerBehaviours/VRRendering.cs
@@ -45,6 +45,9 @@ namespace GTFO_VR.Core.PlayerBehaviours
                 m_fpsCamera.transform.position = HMD.GetWorldPosition();
             }
 
+            // Weapons with sights only render their sights otherwise. 
+            Shader.DisableKeyword("FPS_RENDERING_ALLOWED");
+
             m_fpsCamera.m_camera.transform.parent.localRotation = Quaternion.Euler(HMD.GetVRCameraEulerRelativeToFPSCameraParent());
             m_fpsCamera.UpdateCameraRay();
 

--- a/GTFO_VR/Core/PlayerBehaviours/VRRendering.cs
+++ b/GTFO_VR/Core/PlayerBehaviours/VRRendering.cs
@@ -72,6 +72,7 @@ namespace GTFO_VR.Core.PlayerBehaviours
             m_fpsCamera.m_cullingCamera.RunVisibilityOnPreCull();
             m_fpsCamera.m_preRenderCmds.Clear();
             m_fpsCamera.m_beforeForwardAlpahCmds.Clear();
+            m_fpsCamera.m_preLightingCmds.Clear();
 
             m_fpsRender.ForceMatrixUpdate();
 
@@ -123,15 +124,16 @@ namespace GTFO_VR.Core.PlayerBehaviours
 
         private void PrepareFrame()
         {
-            if (ScreenLiquidManager.LiquidSystem != null)
-                ScreenLiquidManager.LiquidSystem.CollectCommands(m_fpsCamera.m_preRenderCmds);
             if (AirParticleSystem.AirParticleSystem.Current != null)
                 AirParticleSystem.AirParticleSystem.Current.CollectCommands(m_fpsCamera.m_preRenderCmds, m_fpsCamera.m_beforeForwardAlpahCmds);
 
             if (m_fpsCamera.CollectCommandsClustered)
             {
-                ClusteredRendering.Current.CollectCommands(m_fpsCamera.m_preRenderCmds);
+                ClusteredRendering.Current.CollectCommands(m_fpsCamera.m_preRenderCmds, m_fpsCamera.m_preLightingCmds);
             }
+ 
+            if (ScreenLiquidManager.LiquidSystem != null)
+                ScreenLiquidManager.LiquidSystem.CollectCommands(m_fpsCamera.m_preRenderCmds);
 
             if (m_fpsCamera.CollectCommandsGUIX && GUIX_Manager.isSetup)
             {
@@ -143,8 +145,8 @@ namespace GTFO_VR.Core.PlayerBehaviours
                 MapDetails.Current.CollectCommands(m_fpsCamera.m_preRenderCmds);
             }
 
-            Vector4 projectionParams = ClusteredRendering.GetProjectionParams(ClusteredRendering.Current.m_camera);
-            Vector4 zbufferParams = ClusteredRendering.GetZBufferParams(ClusteredRendering.Current.m_camera);
+            Vector4 projectionParams = RenderUtils.GetProjectionParams(ClusteredRendering.Current.m_camera);
+            Vector4 zbufferParams = RenderUtils.GetZBufferParams(ClusteredRendering.Current.m_camera);
             m_fpsCamera.m_preRenderCmds.SetGlobalVector(ClusteredRendering.ID_ProjectionParams, projectionParams);
             m_fpsCamera.m_preRenderCmds.SetGlobalVector(ClusteredRendering.ID_ZBufferParams, zbufferParams);
 
@@ -152,6 +154,7 @@ namespace GTFO_VR.Core.PlayerBehaviours
             Shader.SetGlobalMatrix("_MATRIX_VP", GL.GetGPUProjectionMatrix(m_fpsCamera.m_camera.projectionMatrix, false) * m_fpsCamera.m_camera.worldToCameraMatrix);
             Shader.SetGlobalMatrix("_MATRIX_IV", this.transform.worldToLocalMatrix);
             Shader.SetGlobalInt("_FrameIndex", m_fpsCamera.m_frameIndex++);
+            Shader.SetGlobalInt("_GameCameraActive", 1);
         }
 
         // Force FOV/Aspects and position match up for all relevant game cameras

--- a/GTFO_VR/Core/UI/VRWorldSpaceUI.cs
+++ b/GTFO_VR/Core/UI/VRWorldSpaceUI.cs
@@ -25,11 +25,13 @@ namespace GTFO_VR.UI
         public static PUI_InteractionPrompt interactionBar;
         public static PUI_Compass compass;
         public static PUI_WardenIntel intel;
+        public static PUI_ObjectiveTimer timer;
 
         private GameObject m_statusBarHolder;
         private GameObject m_interactionBarHolder;
         private GameObject m_compassHolder;
         private GameObject m_intelHolder;
+        private GameObject m_timerHolder;
 
         // Compass will not be visible after this distance from the center of its rect
         private float m_compassCullDistance = 1.2f;
@@ -46,11 +48,12 @@ namespace GTFO_VR.UI
             interactGUI = interaction;
         }
 
-        public static void SetPlayerGUIRef(PlayerGuiLayer playerGUIRef, PUI_Compass compassRef, PUI_WardenIntel intelRef)
+        public static void SetPlayerGUIRef(PlayerGuiLayer playerGUIRef, PUI_Compass compassRef, PUI_WardenIntel intelRef, PUI_ObjectiveTimer timerRef)
         {
             intel = intelRef;
             compass = compassRef;
             playerGUI = playerGUIRef;
+            timer = timerRef;
         }
 
         private void Start()
@@ -60,6 +63,7 @@ namespace GTFO_VR.UI
             m_interactionBarHolder = new GameObject("VR_InteractionUI");
             m_compassHolder = new GameObject("CompassHolder");
             m_intelHolder = new GameObject("IntelHolder");
+            m_timerHolder = new GameObject("TimerHolder");
             Invoke(nameof(VRWorldSpaceUI.Setup), 1f);
         }
 
@@ -69,6 +73,9 @@ namespace GTFO_VR.UI
             SetupElement(interactionBar.transform, m_interactionBarHolder.transform, 0.0018f, holderScale:1.1f);
             SetupElement(compass.transform, m_compassHolder.transform, 0.0036f, false, holderScale:1.35f);
             SetupElement(intel.transform, m_intelHolder.transform, 0.0018f, holderScale:1f);
+
+            //TODO: timer is destroyed when expedition is changed, so it will vanish and not be repopulated here.
+            SetupElement(timer.transform, m_timerHolder.transform, 0.0036f, false, holderScale: 1f);
 
             SetTextShader(compass.transform, VRAssets.TextSphereClip);
             SetSpriteRendererShader(compass.transform, VRAssets.SpriteSphereClip);
@@ -101,6 +108,7 @@ namespace GTFO_VR.UI
             UpdateStatus();
             UpdateCompass();
             UpdateIntel();
+            UpdateTimer();
         }
 
         private void UpdateIntel()
@@ -180,6 +188,28 @@ namespace GTFO_VR.UI
             Shader.SetGlobalColor("_ClippingSphere", new Color(compassPos.x, compassPos.y, compassPos.z, m_compassCullDistance));
         }
 
+        private void UpdateTimer()
+        {
+            if (m_timerHolder == null)
+            {
+                Log.Error("m_timerHolder was null!");
+                return;
+            }
+            
+            if (timer != null && timer.transform.localScale.x > 0.0037)
+            {
+                timer.transform.localScale = Vector3.one * 0.0036f;
+            }
+
+            // do not use playerGUI.TimerOnMainScreenVisible, it is not true when it should or is be visible. 
+            m_timerHolder.SetActive(playerGUI.IsVisible()); 
+            if (m_timerHolder.activeSelf)
+            {
+                m_timerHolder.transform.position = GetTimerPosition();
+                m_timerHolder.transform.rotation = Quaternion.LookRotation(HMD.GetFlatForwardDirection());
+            }
+        }
+
         public static void PrepareNavMarker(NavMarker n)
         {
             n.transform.SetParent(null);
@@ -223,6 +253,11 @@ namespace GTFO_VR.UI
         private Vector3 GetCompassPosition()
         {
             return HMD.GetWorldPosition() + HMD.GetFlatForwardDirection() * 1.45f + new Vector3(0, 2.15f, 0);
+        }
+
+        private Vector3 GetTimerPosition()
+        {
+            return HMD.GetWorldPosition() + HMD.GetFlatForwardDirection() * 1.45f + new Vector3(0, 1.50f, 0);
         }
 
         private Vector3 GetInteractionPromptPosition()
@@ -341,6 +376,11 @@ namespace GTFO_VR.UI
             {
                 m_intelHolder.transform.DetachChildren();
                 Destroy(m_intelHolder);
+            }
+            if (m_timerHolder != null)
+            {
+                m_timerHolder.transform.DetachChildren();
+                Destroy(m_timerHolder);
             }
             SteamVR_Events.NewPosesApplied.Remove(OnNewPoses);
             PlayerOrigin.OnOriginShift -= SnapUIToPlayerView;

--- a/GTFO_VR/Core/UI/VRWorldSpaceUI.cs
+++ b/GTFO_VR/Core/UI/VRWorldSpaceUI.cs
@@ -26,12 +26,14 @@ namespace GTFO_VR.UI
         public static PUI_Compass compass;
         public static PUI_WardenIntel intel;
         public static PUI_ObjectiveTimer timer;
+        public static PUI_Subtitles subtitles;
 
         private GameObject m_statusBarHolder;
         private GameObject m_interactionBarHolder;
         private GameObject m_compassHolder;
         private GameObject m_intelHolder;
         private GameObject m_timerHolder;
+        private GameObject m_subtitlesHolder;
 
         // Compass will not be visible after this distance from the center of its rect
         private float m_compassCullDistance = 1.2f;
@@ -48,12 +50,13 @@ namespace GTFO_VR.UI
             interactGUI = interaction;
         }
 
-        public static void SetPlayerGUIRef(PlayerGuiLayer playerGUIRef, PUI_Compass compassRef, PUI_WardenIntel intelRef, PUI_ObjectiveTimer timerRef)
+        public static void SetPlayerGUIRef(PlayerGuiLayer playerGUIRef, PUI_Compass compassRef, PUI_WardenIntel intelRef, PUI_ObjectiveTimer timerRef, PUI_Subtitles subtitlesRef)
         {
             intel = intelRef;
             compass = compassRef;
             playerGUI = playerGUIRef;
             timer = timerRef;
+            subtitles = subtitlesRef;
         }
 
         private void Start()
@@ -64,6 +67,7 @@ namespace GTFO_VR.UI
             m_compassHolder = new GameObject("CompassHolder");
             m_intelHolder = new GameObject("IntelHolder");
             m_timerHolder = new GameObject("TimerHolder");
+            m_subtitlesHolder = new GameObject("SubtitlesHolder");
             Invoke(nameof(VRWorldSpaceUI.Setup), 1f);
         }
 
@@ -73,6 +77,7 @@ namespace GTFO_VR.UI
             SetupElement(interactionBar.transform, m_interactionBarHolder.transform, 0.0018f, holderScale:1.1f);
             SetupElement(compass.transform, m_compassHolder.transform, 0.0036f, false, holderScale:1.35f);
             SetupElement(intel.transform, m_intelHolder.transform, 0.0018f, holderScale:1f);
+            SetupElement(subtitles.transform, m_subtitlesHolder.transform, 0.0018f, holderScale: 1f);
 
             //TODO: timer is destroyed when expedition is changed, so it will vanish and not be repopulated here.
             SetupElement(timer.transform, m_timerHolder.transform, 0.0036f, false, holderScale: 1f);
@@ -109,6 +114,7 @@ namespace GTFO_VR.UI
             UpdateCompass();
             UpdateIntel();
             UpdateTimer();
+            UpdateSubtitles();
         }
 
         private void UpdateIntel()
@@ -210,6 +216,27 @@ namespace GTFO_VR.UI
             }
         }
 
+        private void UpdateSubtitles()
+        {
+            if (m_subtitlesHolder == null)
+            {
+                Log.Error("m_subtitlesHolder was null!");
+                return;
+            }
+
+            if (subtitles != null && subtitles.transform.localScale.x > 0.02f)
+            {
+                subtitles.transform.localScale = Vector3.one * 0.0018f;
+            }
+
+            m_subtitlesHolder.SetActive(playerGUI.IsVisible());
+            if (m_subtitlesHolder.activeSelf)
+            {
+                m_subtitlesHolder.transform.position = GetSubtitlesPosition();
+                m_subtitlesHolder.transform.rotation = Quaternion.LookRotation(HMD.GetFlatForwardDirection());
+            }
+        }
+
         public static void PrepareNavMarker(NavMarker n)
         {
             n.transform.SetParent(null);
@@ -258,6 +285,11 @@ namespace GTFO_VR.UI
         private Vector3 GetTimerPosition()
         {
             return HMD.GetWorldPosition() + HMD.GetFlatForwardDirection() * 1.45f + new Vector3(0, 1.50f, 0);
+        }
+
+        private Vector3 GetSubtitlesPosition()
+        {
+            return HMD.GetWorldPosition() + HMD.GetFlatForwardDirection() * 1.45f + new Vector3(0, -0.75f, 0);
         }
 
         private Vector3 GetInteractionPromptPosition()
@@ -381,6 +413,11 @@ namespace GTFO_VR.UI
             {
                 m_timerHolder.transform.DetachChildren();
                 Destroy(m_timerHolder);
+            }
+            if (m_subtitlesHolder != null)
+            {
+                m_subtitlesHolder.transform.DetachChildren();
+                Destroy(m_subtitlesHolder);
             }
             SteamVR_Events.NewPosesApplied.Remove(OnNewPoses);
             PlayerOrigin.OnOriginShift -= SnapUIToPlayerView;

--- a/GTFO_VR/GTFO_VR.csproj
+++ b/GTFO_VR/GTFO_VR.csproj
@@ -107,6 +107,7 @@
     <Compile Include="Injections\Events\InjectTentacleAttackEvents.cs" />
     <Compile Include="Injections\GameHooks\InjectPlayerGUIRef.cs" />
     <Compile Include="Injections\GameHooks\InjectVRStart.cs" />
+    <Compile Include="Injections\Gameplay\InjectDisablePlayerMoveTo.cs" />
     <Compile Include="Injections\Input\InjectKeyInput.cs" />
     <Compile Include="Injections\Rendering\InjectClusteredRenderingResolutionTweak.cs" />
     <Compile Include="Injections\Rendering\InjectDisableFPSCameraRenderUpdate.cs" />

--- a/GTFO_VR/Injections/GameHooks/InjectPlayerGUIRef.cs
+++ b/GTFO_VR/Injections/GameHooks/InjectPlayerGUIRef.cs
@@ -11,7 +11,7 @@ namespace GTFO_VR.Injections.GameHooks
     {
         private static void Postfix(PlayerGuiLayer __instance)
         {
-            VRWorldSpaceUI.SetPlayerGUIRef(__instance, __instance.m_compass, __instance.m_wardenIntel, __instance.m_objectiveTimer);
+            VRWorldSpaceUI.SetPlayerGUIRef(__instance, __instance.m_compass, __instance.m_wardenIntel, __instance.m_objectiveTimer, __instance.m_subtitles);
             __instance.m_compass.transform.localScale *= .75f;
         }
     }

--- a/GTFO_VR/Injections/GameHooks/InjectPlayerGUIRef.cs
+++ b/GTFO_VR/Injections/GameHooks/InjectPlayerGUIRef.cs
@@ -11,7 +11,7 @@ namespace GTFO_VR.Injections.GameHooks
     {
         private static void Postfix(PlayerGuiLayer __instance)
         {
-            VRWorldSpaceUI.SetPlayerGUIRef(__instance, __instance.m_compass, __instance.m_wardenIntel);
+            VRWorldSpaceUI.SetPlayerGUIRef(__instance, __instance.m_compass, __instance.m_wardenIntel, __instance.m_objectiveTimer);
             __instance.m_compass.transform.localScale *= .75f;
         }
     }

--- a/GTFO_VR/Injections/Gameplay/InjectDisablePlayerMoveTo.cs
+++ b/GTFO_VR/Injections/Gameplay/InjectDisablePlayerMoveTo.cs
@@ -1,0 +1,23 @@
+﻿using HarmonyLib;
+using Player;
+
+namespace GTFO_VR.Injections.Gameplay
+{
+    /// <summary>
+    /// Game will attempt to move player closer to terminal, but uses camera forward and sends you sliding off to the side. Disable when in terminal.
+    /// </summary>
+    ///
+    [HarmonyPatch(typeof(PlayerCharacterController), nameof(PlayerCharacterController.MoveTo))]
+    internal class InjectExternalForce
+    {
+        private static bool Prefix(PlayerCharacterController __instance)
+        {
+
+            if (__instance.m_owner.IsLocallyOwned && FocusStateManager.CurrentState == eFocusState.ComputerTerminal)
+            {
+                return false;
+            }
+            return true;
+        }
+    }
+}

--- a/GTFO_VR/Injections/Rendering/InjectFPRendering.cs
+++ b/GTFO_VR/Injections/Rendering/InjectFPRendering.cs
@@ -104,4 +104,23 @@ namespace GTFO_VR.Injections.Rendering
                 PlayerBackpackManager.SetFPSRendering(gfxArm, false);
         }
     }
+
+    /// <summary>
+    /// Disables FPS arms rendering, it's really wonky in VR so it's better to not see it at all
+    /// </summary>
+
+    [HarmonyPatch(typeof(PlayerFPSBody), nameof(PlayerFPSBody.SetVisible))]
+    internal class InjectDisableFPSArmsSetVisible
+    {
+        private static void Postfix(PlayerFPSBody __instance, bool state)
+        {
+            if (state)
+            {
+                __instance.SetGFXVisible(__instance.m_gfxArms, false);
+                foreach (GameObject gfxArm in __instance.m_gfxArms)
+                    PlayerBackpackManager.SetFPSRendering(gfxArm, false);
+            }
+        }
+    }
+
 }

--- a/GTFO_VR/Injections/UI/InjectWatchObjectives.cs
+++ b/GTFO_VR/Injections/UI/InjectWatchObjectives.cs
@@ -6,10 +6,12 @@ using LevelGeneration;
 
 namespace GTFO_VR.Injections.UI
 {
+    // As of R7 this patch will crash the game when it is called, at random. Commented out for now.
+
     /// <summary>
     /// Replicate new objectives on the VR watch
     /// </summary>
-
+    /*
     [HarmonyPatch(typeof(PlayerGuiLayer), nameof(PlayerGuiLayer.UpdateObjectives))]
     internal class InjectWatchObjectives
     {
@@ -29,4 +31,5 @@ namespace GTFO_VR.Injections.UI
             Log.Debug($"Got new subobjective! - {txt}");
         }
     }
+    */
 }


### PR DESCRIPTION
### What does this PR do?

Adds basic support for Rundown 7. It also adds the timer and subtitles to the world UI.
After playing A1 and B1, everything seems to work about as well as it did for Rundown 6.0 and 6.5.

### Changes

- Fixed things that were broken: 
  - Breaking changes to [`VRRendering`](https://github.com/Nordskog/GTFO_VR_Plugin/blob/R7/GTFO_VR/Core/PlayerBehaviours/VRRendering.cs) copy-pasted from decompiled code.
   - Arms not being hidden fixed by also patching `PlayerFPSBody.SetVisible()` with the same logic already used in the two existing hooks in [`InjectFPRendering`](https://github.com/Nordskog/GTFO_VR_Plugin/blob/R7/GTFO_VR/Injections/Rendering/InjectFPRendering.cs#L112). This is called with false then true every time you swap weapons, so only does work when true.
   - Some weapons were rendering with only their sights visible. Fixed by disabling the `FPS_RENDERING_ALLOWED` shader keyword globally in [`VRRendering`](https://github.com/Nordskog/GTFO_VR_Plugin/blob/R7/GTFO_VR/Core/PlayerBehaviours/VRRendering.cs#L49).
   - R7 tries to move player directly infront of terminal so the third-person typing animation looks right. It assumes the camera will be facing straight forward, which is obviously not the case in VR, causing the player to slide forward and to the sides. `PLOC_OnTerminal.FixedUpdate()` does the math then calls `PlayerCharacterController.MoveTo()`. Since the former may include addtional logic at some point, `MoveTo()` was instead [patched to do nothing while on the terminal](https://github.com/Nordskog/GTFO_VR_Plugin/blob/R7/GTFO_VR/Injections/Gameplay/InjectDisablePlayerMoveTo.cs). MoveTo() respects geometry collisions so it probably isn't used for teleportation.
   - The [`PlayerGuiLayer.UpdateObjectives()` and `PUI_GameObjectives.SetMainSubObjective()` patches](https://github.com/Nordskog/GTFO_VR_Plugin/blob/R7/GTFO_VR/Injections/UI/InjectWatchObjectives.cs) crash the game when invoked, even if there is no logic added to the patches. Commented out for now.

- Additions
  - Added [timer ](https://i.imgur.com/SSNpUkt.jpg)( used for countdowns in R6C3 ) and [subtitles ](https://i.imgur.com/T47Lw0K.jpg)( used for story time ) to the world UI. Basically just [copy-pasted what was being done for the existing elements](https://github.com/Nordskog/GTFO_VR_Plugin/blob/R7/GTFO_VR/Core/UI/VRWorldSpaceUI.cs#L80), with tweaked size/position values. The timer is destroyed when you change expeditions and thus vanishes, so that needs to be fixed once we find an R7 expedition with a timer. It is prudent to restart the game between expeditions anyway.