### PR TITLE
Fix NavMarker performance creep

### DIFF
--- a/GTFO_VR/Injections/UI/InjectNavMarkerWorldSpace.cs
+++ b/GTFO_VR/Injections/UI/InjectNavMarkerWorldSpace.cs
@@ -172,6 +172,9 @@ namespace GTFO_VR.Injections.UI
 
                         n.SetDistance(distanceToCamera);
 
+                        n.UpdateTrackingDimension();
+                        n.UpdateEnabledPerDimensionState();
+
                         // Scale up to camera culling distance
                         // If nav marker is beyond that it will place itself back to 60m away
                         tempScale = 1 + Mathf.Clamp(distanceToCamera / 25f, 0, 2.4f);

--- a/GTFO_VR/Injections/UI/InjectNavMarkerWorldSpace.cs
+++ b/GTFO_VR/Injections/UI/InjectNavMarkerWorldSpace.cs
@@ -2,6 +2,7 @@
 using GTFO_VR.Core.VR_Input;
 using GTFO_VR.UI;
 using HarmonyLib;
+using System.Collections.Generic;
 using UnityEngine;
 
 namespace GTFO_VR.Injections.UI
@@ -35,6 +36,70 @@ namespace GTFO_VR.Injections.UI
         }
     }
 
+    /// <summary>
+    /// Get a reference to every marker that is created so we can iterate through them without the performancei issues of accessing NavMarkerLayer.m_markersActive.
+    /// Note that this also includes Locator markers, which we (probably?) don't want to touch. Those are removed in a patch below.
+    /// </summary>
+    [HarmonyPatch(typeof(NavMarkerLayer), nameof(NavMarkerLayer.PrepareMarker))]
+    internal class InjectNavMarkerPrepare
+    {
+        private static void Postfix(NavMarker __result)
+        {
+            InjectNavMarkerWorldSpacePositioning.Markers.Add(__result);
+        }
+    }
+
+    /// <summary>
+    /// Also remove marker from our internal list. As of writing these are always null, so this effectively just clears any null elements.
+    /// NavMarkerLayer.m_markersActive will continue growing forever, filling up with null elements.
+    /// </summary>
+    [HarmonyPatch(typeof(NavMarkerLayer), nameof(NavMarkerLayer.RemoveMarker))]
+    internal class InjectNavMarkerRemove
+    {
+        private static void Prefix(NavMarker marker)
+        {
+            InjectNavMarkerWorldSpacePositioning.Markers.Remove(marker);
+
+            // As of writing the game is passing null for most (all?) of these, so do a quick sweep for nulls.
+            InjectNavMarkerWorldSpacePositioning.Markers.RemoveWhere(mkr => mkr == null);
+        }
+    }
+
+    /// <summary>
+    /// Same as RemoveMarker(), but looks up the marker by its m_trackingObj. Probably not used.
+    /// </summary>
+    [HarmonyPatch(typeof(NavMarkerLayer), nameof(NavMarkerLayer.RemoveMarkerForGO))]
+    internal class InjectNavMarkerRemoveForGO
+    {
+        private static void Prefix(GameObject go)
+        {
+            NavMarker removeMe = null;
+
+            foreach (NavMarker marker in InjectNavMarkerWorldSpacePositioning.Markers)
+            {
+                if ( marker != null && marker.m_trackingObj == go)
+                {
+                    removeMe = marker;
+                    break;
+                }
+            }
+
+            InjectNavMarkerWorldSpacePositioning.Markers.Remove(removeMe);
+        }
+    }
+
+    /// <summary>
+    /// Locator markers are also created in PrepareMarker, but we want to leave them alone. Remove from our list here.
+    /// </summary>
+    [HarmonyPatch(typeof(NavMarkerLayer), nameof(NavMarkerLayer.PlaceLocatorMarker))]
+    internal class InjectNavMarkerLocatorMarkerSkip
+    {
+        private static void Postfix(NavMarker __result)
+        {
+            InjectNavMarkerWorldSpacePositioning.Markers.Remove(__result);
+        }
+    }
+
 
     /// <summary>
     /// Calls into our VR library to handle positioning, scaling and rotating all nav markers
@@ -42,20 +107,25 @@ namespace GTFO_VR.Injections.UI
     [HarmonyPatch(typeof(NavMarkerLayer), nameof(NavMarkerLayer.AfterCameraUpdate))]
     internal class InjectNavMarkerWorldSpacePositioning
     {
+        public static HashSet<NavMarker> Markers = new HashSet<NavMarker>();
+
         private static bool Prefix(NavMarkerLayer __instance)
         {
             if (!__instance.m_visible)
             {
                 return false;
             }
-            UpdateAllNavMarkers(__instance.m_markersActive);
+            UpdateAllNavMarkers(Markers);
             return false;
         }
 
-        internal static void UpdateAllNavMarkers(Il2CppSystem.Collections.Generic.List<NavMarker> m_markersActive)
+        internal static void UpdateAllNavMarkers(HashSet<NavMarker> m_markersActive)
         {
             float tempScale = 1f;
             bool inElevator = FocusStateManager.CurrentState.Equals(eFocusState.InElevator);
+
+            Vector3 hmdPos = HMD.GetWorldPosition();
+            Vector3 hmdFwd = HMD.GetWorldForward();
 
             foreach (NavMarker n in m_markersActive)
             {
@@ -67,9 +137,10 @@ namespace GTFO_VR.Injections.UI
 
                 if (n != null && n.m_trackingObj != null)
                 {
-                    n.transform.position = n.m_trackingObj.transform.position;
+                    Vector3 trackingObjPos = n.m_trackingObj.transform.position;
+                    n.transform.position = trackingObjPos;
 
-                    float dotToCamera = Vector3.Dot((n.m_trackingObj.transform.position - HMD.GetWorldPosition()).normalized, HMD.GetWorldForward());
+                    float dotToCamera = Vector3.Dot((trackingObjPos - hmdPos).normalized, hmdFwd);
 
                     if (dotToCamera < 0)
                     {
@@ -77,14 +148,14 @@ namespace GTFO_VR.Injections.UI
                     }
                     else
                     {
-                        float distanceToCamera = Vector3.Distance(n.m_trackingObj.transform.position, HMD.GetWorldPosition());
-                        Vector3 hmdToTrackObj = (n.m_trackingObj.transform.position - HMD.GetWorldPosition()).normalized;
+                        float distanceToCamera = Vector3.Distance(trackingObjPos, hmdPos);
+                        Vector3 hmdToTrackObj = (trackingObjPos - hmdPos).normalized;
                         Quaternion rotToCamera = Quaternion.LookRotation(hmdToTrackObj.normalized);
                         n.transform.rotation = rotToCamera;
 
                         if (distanceToCamera > 60)
                         {
-                            n.transform.position = HMD.GetWorldPosition() + hmdToTrackObj * 60f;
+                            n.transform.position = hmdPos + hmdToTrackObj * 60f;
                         }
 
                         if (dotToCamera > 0.94f)
@@ -98,10 +169,7 @@ namespace GTFO_VR.Injections.UI
                         {
                             n.SetState(NavMarkerState.Visible);
                         }
-                        if(n.m_distance != null && n.m_distance.fontSharedMaterial != null)
-                        {
-                            n.m_distance.fontSharedMaterial.shader = VRAssets.GetTextNoCull();
-                        }
+
                         n.SetDistance(distanceToCamera);
 
                         // Scale up to camera culling distance


### PR DESCRIPTION
### What?

`NavMarker`s are processed every frame to orient them in world-space, replacing the original logic of `NavMarkerLayer.AfterCameraUpdate()` in [`UpdateAllNavMarkers()`](https://github.com/DSprtn/GTFO_VR_Plugin/blob/master/GTFO_VR/Injections/UI/InjectNavMarkerWorldSpace.cs#L51)
In order to do this we iterate through `NavMarkerLayer.m_markersActive`, which has two problems:

1. Accessing the elements of this particular List is very expensive for some reason.
2. GTFO is broken and never removes destroyed markers from this list.

By their powers combined, performance slowly tanks as the number of null elements grows into the hundreds and probably eventually thousands. You can hit 100 markers within a few minutes if you wake a couple of rooms with a biotracker, and by the time you pass 200 the performance penalty is up to 2ms.

### Changes

Maintain our own list of markers by patching a few of `NavMarkerLayer`'s functions for adding and removing them. Accessing this has no performance penalty, and we can clean the nulls entries too.

**New patches:**
[`NavMarkerLayer.PrepareMarker()`](https://github.com/Nordskog/GTFO_VR_Plugin/blob/NavMarkerPerformance/GTFO_VR/Injections/UI/InjectNavMarkerWorldSpace.cs#L43) - Called on creation of all markers, add to our list here. This includes Locator makers that we don't want to mess with so...
[`NavMarkerLayer.PlaceLocatorMarker()`](https://github.com/Nordskog/GTFO_VR_Plugin/blob/NavMarkerPerformance/GTFO_VR/Injections/UI/InjectNavMarkerWorldSpace.cs#L94) - Gets a reference to Locator markers on creation and removes them from our list
[`NavMarkerLayer.RemoveMarker()`](https://github.com/Nordskog/GTFO_VR_Plugin/blob/NavMarkerPerformance/GTFO_VR/Injections/UI/InjectNavMarkerWorldSpace.cs#L56) - Remove markers from list. Value passed to this is always null, so we also prune our list of null values here.
[`NavMarkerLayer.RemoveMarkerForGO()`](https://github.com/Nordskog/GTFO_VR_Plugin/blob/NavMarkerPerformance/GTFO_VR/Injections/UI/InjectNavMarkerWorldSpace.cs#L71) - Find marker with m_trackingObj matching input and remove from list. Not used as far as I can tell, but implemented anyway.

The function that does all work, [`UpdateAllNavMarkers`](https://github.com/Nordskog/GTFO_VR_Plugin/blob/NavMarkerPerformance/GTFO_VR/Injections/UI/InjectNavMarkerWorldSpace.cs#L122) has also been modified to improve performance ( by you ). Notably some expensive calculations are cached, and any logic checking/setting the text shader has been removed. 
Still seems to work all the same.

R6 / R7 code also includes `NavMarker.UpdateTrackingDimension()` and `UpdateEnabledPerDimensionState()` and the end of `NavMarker.AfterCameraUpdate()`'s original logic. 
These two mostly only modify `NavMarker.m_trackingPosAtLastDimensionUpdate.x/y/z`, as well as toggling the marker GO depending on the dimension. 
Their absence is likely responsible for player name/info vanishing when outside ( different dimension ), and adding them doesn't seem like it would nor has it broken anything, so [I've added them too](https://github.com/Nordskog/GTFO_VR_Plugin/blob/NavMarkerPerformance/GTFO_VR/Injections/UI/InjectNavMarkerWorldSpace.cs#L175).