### PR TITLE
Fixed watch objectives, include progressions

### DIFF
--- a/GTFO_VR/Injections/UI/InjectWatchObjectives.cs
+++ b/GTFO_VR/Injections/UI/InjectWatchObjectives.cs
@@ -3,33 +3,56 @@ using GTFO_VR.Core;
 using GTFO_VR.UI;
 using HarmonyLib;
 using LevelGeneration;
+using Localization;
 
 namespace GTFO_VR.Injections.UI
 {
-    // As of R7 this patch will crash the game when it is called, at random. Commented out for now.
-
     /// <summary>
-    /// Replicate new objectives on the VR watch
+    /// Replicate new objectives on the VR watch. 
     /// </summary>
-    /*
+    
     [HarmonyPatch(typeof(PlayerGuiLayer), nameof(PlayerGuiLayer.UpdateObjectives))]
     internal class InjectWatchObjectives
     {
-        private static void Postfix(LG_LayerType layer,string mainObjective)
+        public static PUI_GameObjectives PlayerGuiLayer_PUI_GameObjectives_Instance = null;
+
+        private static void Prefix(PlayerGuiLayer __instance)
         {
-            Watch.Current?.UpdateMainObjective(mainObjective);
-            Log.Debug($"Got new objective! - {mainObjective}");
+            // Keep track of the instance so we can skip the PUI_GameObjectives.SetProgressionObjective() patch
+            // when called on any other instance. Unfortunately patching that method is the only way.
+            PlayerGuiLayer_PUI_GameObjectives_Instance = __instance.WardenObjectives;
+        }
+
+        private static void Postfix(PlayerGuiLayer __instance)
+        {
+            Watch.Current?.UpdateObjective(__instance.m_wardenObjective);
+            Log.Debug($"Got new objectives!");
+        }
+    }
+    
+    [HarmonyPatch(typeof(PUI_GameObjectives), nameof(PUI_GameObjectives.SetProgressionObjective))]
+    internal class InjectWatchObjectivesProgression
+    {
+        private static void Postfix(PUI_GameObjectives __instance)
+        {
+            if ( __instance == InjectWatchObjectives.PlayerGuiLayer_PUI_GameObjectives_Instance)
+            {
+                Watch.Current?.UpdateObjective(__instance);
+                Log.Debug($"Got new progression!");
+            }
         }
     }
 
-    [HarmonyPatch(typeof(PUI_GameObjectives), nameof(PUI_GameObjectives.SetMainSubObjective))]
-    internal class InjectWatchSubObjectives
+    [HarmonyPatch(typeof(PUI_GameObjectives), nameof(PUI_GameObjectives.RemoveProgressionObjective))]
+    internal class InjectWatchObjectivesProgressionRemove
     {
-        private static void Postfix(string txt)
+        private static void Postfix(PUI_GameObjectives __instance)
         {
-            Watch.Current?.UpdateSubObjective(txt);
-            Log.Debug($"Got new subobjective! - {txt}");
+            if (__instance == InjectWatchObjectives.PlayerGuiLayer_PUI_GameObjectives_Instance)
+            {
+                Watch.Current?.UpdateObjective(__instance);
+                Log.Debug($"Got progression removal!");
+            }
         }
     }
-    */
 }


### PR DESCRIPTION
### What?

This PR fixes the objectives displayed on the watch.

Previously the watch would display the `mainObjective`and `mainSubObjective`.
As of writing these ultimately get added to `progressions`, along with any other progression objectives, so we just display all the progressions.

All the information normally visible in the upper-left corner of the screen should now be visible on the watch, including things like key names and uplink IP addresses. 

https://i.imgur.com/Zm4Hrxx.jpg
https://i.imgur.com/K2OkJJv.jpg
https://i.imgur.com/64GOnmB.jpg

### How?

Ultimately we just iterate through `PUI_GameObjectives.m_progressionObjectives`. The problem lies in getting the correct instance of `PUI_GameObjectives`, and knowing when to check it for changes.

As before, `PlayerGuiLayer.UpdateObjectives()` is patched to intercept when the main objective changes. 
Unfortunately, its other objective-updated functions are not called when you would expect them to be, and most notably `PlayerGuiLayer.SetProgressionObjective()` is never called.

Since `PlayerGuiLayer.SetProgressionObjective()` is never called we are kind of stuck with patching  `PUI_GameObjectives.SetProgressionObjective()` and its brother `PUI_GameObjectives.RemoveProgressionObjective()` instead, but there are multiple instances of `PUI_GameObjectives`, and some are either empty or don't list the same set of objectives.

We store an reference to the relevant instance of `PUI_GameObjectives()` before `PlayerGuiLayer.UpdateObjectives()`, and only execute the above patches if they are called by the same instance. 

### Details

The text was made slightly transparent, as otherwise it glows brightly and all the colors appear pure white.
\<Indent\> is removed from the text as it breaks the formatting.

There are 3 "layers" of objectives, presumably corresponding to main, secondary, and overload.
I'm fairly sure the objectives are just swapped out wholesale for different layers, so secondary and overload objectives shouldn't break anything.
