### PR TITLE
Add option to not display chat when toggling watch screens

### DIFF
--- a/GTFO_VR/Core/UI/Watch.cs
+++ b/GTFO_VR/Core/UI/Watch.cs
@@ -481,12 +481,21 @@ namespace GTFO_VR.UI
         public void SwitchState()
         {
             int maxStateIndex = Enum.GetValues(typeof(WatchState)).Length - 1;
-            int nextIndex = (int)m_currentState + 1;
+            int nextIndex = (int)m_currentState;
 
-            if (nextIndex > maxStateIndex)
+            while(true)
             {
-                nextIndex = 0;
+                nextIndex++;
+                if (nextIndex > maxStateIndex)
+                    nextIndex = 0;
+
+                // If current index is chat and we want to skip it, repeat loop.
+                if (nextIndex == (int)WatchState.Chat && !VRConfig.configDisplayChatOnWatch.Value)
+                    continue;
+
+                break;
             }
+
             SwitchState((WatchState)nextIndex);
             SteamVR_InputHandler.TriggerHapticPulse(0.025f, 1 / .025f, 0.3f, Controllers.GetDeviceFromHandType(Controllers.offHandControllerType));
         }

--- a/GTFO_VR/Core/VRConfig.cs
+++ b/GTFO_VR/Core/VRConfig.cs
@@ -18,6 +18,7 @@ namespace GTFO_VR.Core
         internal static ConfigEntry<float> configWatchScaling;
         internal static ConfigEntry<bool> configUseNumbersForAmmoDisplay;
         internal static ConfigEntry<string> configWatchColor;
+        internal static ConfigEntry<bool> configDisplayChatOnWatch;
         internal static ConfigEntry<int> configCrouchHeight;
         internal static ConfigEntry<bool> configUseLaserPointerOnWeapons;
         internal static ConfigEntry<bool> configUseWeaponHaptics;
@@ -96,6 +97,7 @@ namespace GTFO_VR.Core
             configWatchColor = BindStringDropdown(file, "Watch", "Watch color", "WHITE", "Color to use for watch", "Watch color", new string[] { "WHITE", "RED", "GREEN", "BLUE", "CYAN", "YELLOW", "MAGENTA", "ORANGE", "BLACK" });
             configWatchScaling = BindFloat(file, "Watch", "Watch scale multiplier", 1f, 0.8f, 1.5f, "Watch size multiplier", "Watch size");
             configUseNumbersForAmmoDisplay = BindBool(file, "Watch", "Use numbers for ammo display?", false, "If true, current ammo and max ammo will be displayed as numbers on the watch", "Use number display for ammo");
+            configDisplayChatOnWatch = BindBool(file, "Watch", "Display chat on watch?", false, "If true, the watch will also display the chat when toggled, in addition to player status and objectives. This does not affect the radial menu", "Display chat on watch?");
 
             BindHeader("Weapons");
             configUseWeaponHaptics = BindBool(file, "Haptics", "Use haptics for shooting?", true, "If true, haptics effect will trigger when shooting weapons.", "Weapon haptics");


### PR DESCRIPTION
### What

This PR adds an option to display ( or not display ) the `chat` screen when toggling between the different screens on the `watch`.
When enabled, it will toggle between `player status`, `chat`, and `mission objectives`.
When disabled ( default state ), the watch will only toggle between `player status` and `mission objectives`.

The `radial menu` has been left untouched, and still contains an item for the `chat`. This continues to work as before.
Unlike when toggling between the screens with a single button, having the `chat` item available doesn't really get in the way of anything, so might as well keep it there.

### How

Increment index -> if chat and setting not enabled then increment again.

