### PR TITLE
Nav marker visibility

### DIFF
--- a/GTFO_VR/Injections/UI/InjectNavMarkerWorldSpace.cs
+++ b/GTFO_VR/Injections/UI/InjectNavMarkerWorldSpace.cs
@@ -132,7 +132,7 @@ namespace GTFO_VR.Injections.UI
                     return;
                 }
 
-                if (n != null && n.m_trackingObj != null)
+                if (n != null && n.gameObject.active && n.m_trackingObj != null)
                 {
                     Vector3 trackingObjPos = n.m_trackingObj.transform.position;
                     n.transform.position = trackingObjPos;

--- a/GTFO_VR/Injections/UI/InjectNavMarkerWorldSpace.cs
+++ b/GTFO_VR/Injections/UI/InjectNavMarkerWorldSpace.cs
@@ -112,10 +112,6 @@ namespace GTFO_VR.Injections.UI
 
         private static bool Prefix(NavMarkerLayer __instance)
         {
-            if (!__instance.m_visible)
-            {
-                return false;
-            }
             UpdateAllNavMarkers(Markers);
             return false;
         }

--- a/GTFO_VR/Injections/UI/InjectNavMarkerWorldSpace.cs
+++ b/GTFO_VR/Injections/UI/InjectNavMarkerWorldSpace.cs
@@ -32,6 +32,7 @@ namespace GTFO_VR.Injections.UI
             foreach (SpriteRenderer r in __instance.transform.GetComponentsInChildren<SpriteRenderer>())
             {
                 r.material.shader = VRAssets.SpriteAlwaysRender;
+                r.material.renderQueue = 4001;
             }
         }
     }


### PR DESCRIPTION
### What

This PR fixes

- Nav markers ( notably scanner markers ) [not rendering through glass](https://i.imgur.com/r095qW0.png)
- Terminal pings not being visible when in the terminal

### How

**Glass**

We already mess with the `NavMarker` icon material when they are set up, but only set the shader.
`Renderqueue` changed to 4001 to render ontop of everything, glass included
```csharp
foreach (SpriteRenderer r in __instance.transform.GetComponentsInChildren<SpriteRenderer>())
{
    r.material.shader = VRAssets.SpriteAlwaysRender;
    r.material.renderQueue = 4001;    // New
}
````
This does still affect a number of other world-space UI elements ( e.g. player outlines ), and the text accompanying nav markers does not render through anything, but as long as the marker icons are visible it's mostly a non-issue.

**Terminal pings**

[0ce1bb5](https://github.com/DSprtn/GTFO_VR_Plugin/commit/41f03a087849a016e2fec70920d55eded0781266) added a check to see if `NavMarkerLayer.m_visible` and skips all the world-space nav marker logic if false.
Unfortunately this is false when the player is in the terminal, resulting in pings not displaying until they leave it.
Could add another check for whether or not the user is in the terminal at the time, but realistically the impact of a few markers is negligible, so I just reverted that for now. Menu stutterhell doesn't really seem to be a vram issue anyway, though it sure behaves like it.

**Other**

`UpdateAllNavMarkers()` was also modified to skip any markers whose `GameObject` is inactive. It keeps a number of these around and in the list of "active" markers, despite them being inactive ( not just out-of-view inactive, but doesn't-need-to-exist-anymore inactive ). 




