### PR TITLE
Fix selecting commands with [brackets], ctrl-c to cancel -T ping

### DIFF
--- a/GTFO_VR/Core/UI/Terminal/KeyboardDefinition/KeyDefinition.cs
+++ b/GTFO_VR/Core/UI/Terminal/KeyboardDefinition/KeyDefinition.cs
@@ -61,6 +61,7 @@ namespace GTFO_VR.Core.UI.Terminal.KeyboardDefinition
             this.Label = label;
             this.Parameters = layoutParameters;
             PopulateInput();
+            PopulateKeycode();
         }
 
         public KeyDefinition(KeyType type, string label) : this(type, label, new LayoutParameters() ){ }
@@ -74,6 +75,7 @@ namespace GTFO_VR.Core.UI.Terminal.KeyboardDefinition
             this.Label = label;
             this.Parameters = layoutParameters;
             PopulateInput();
+            PopulateKeycode();
         }
 
         /// <summary>
@@ -133,6 +135,54 @@ namespace GTFO_VR.Core.UI.Terminal.KeyboardDefinition
                         this.Input = "\t";
                         break;
                     }
+            }
+        }
+
+        public bool IsModifier()
+        {
+            switch (this.KeyType)
+            {
+                case KeyType.CTRL:
+                case KeyType.ALT:
+                case KeyType.SHIFT:
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        public void PopulateKeycode()
+        {
+            // Backspace is the other non-symbol buttons correspond to special input actions, so skip those
+            switch (this.KeyType)
+            {
+                case KeyType.CTRL:
+                {
+                    KeyCode = KeyCode.LeftControl;  // This is the one the game looks for
+                    break;
+                }
+                case KeyType.SHIFT:
+                {
+                    KeyCode = KeyCode.LeftShift;
+                    break;
+                }
+                case KeyType.ALT:
+                {
+                    KeyCode = KeyCode.LeftAlt;
+                    break;
+                }
+                case KeyType.SPACE:
+                {
+                    KeyCode = KeyCode.Space;
+                    break;
+                }
+                case KeyType.ENTER:
+                {
+                    KeyCode = KeyCode.KeypadEnter;
+                    break;
+                }
+                default:
+                    { break; }
             }
         }
 
@@ -214,15 +264,23 @@ namespace GTFO_VR.Core.UI.Terminal.KeyboardDefinition
             /////////////////////
 
             m_button.OnClick.AddListener( (UnityAction) (() => HandleClick(keyboardRoot)) );
-            if (RepeatKey)
-                m_button.RepeatKey = true;
+            m_button.RepeatKey = RepeatKey;
+            m_button.ModifierKey = IsModifier();
 
             return buttonRoot;
         }
 
         private void HandleClick( TerminalKeyboardInterface keyboardRoot )
         {
-            keyboardRoot.HandleInput(this);
+            if (IsModifier() )
+            {
+                keyboardRoot.HandleModifier(this, m_button.IsToggled);
+            }
+            else
+            {
+                keyboardRoot.HandleInput(this);
+            }
+  
         }
 
         public void AddChild(KeyboardLayout layout)

--- a/GTFO_VR/Core/UI/Terminal/Pointer/MonoPointerEvent.cs
+++ b/GTFO_VR/Core/UI/Terminal/Pointer/MonoPointerEvent.cs
@@ -57,6 +57,15 @@ namespace GTFO_VR.Core.UI.Terminal.Pointer
         }
 
         /// <summary>
+        /// The event was cancelled. Target should revert to its default state.
+        /// </summary>
+        [HideFromIl2Cpp]
+        public virtual void OnFocusLost(PointerEvent ev)
+        {
+
+        }
+
+        /// <summary>
         /// Implementation may provide a different pointer size
         /// </summary>
         [HideFromIl2Cpp]

--- a/GTFO_VR/Core/UI/Terminal/Pointer/PhysicalButton.cs
+++ b/GTFO_VR/Core/UI/Terminal/Pointer/PhysicalButton.cs
@@ -158,6 +158,29 @@ namespace GTFO_VR.Core.UI.Terminal.Pointer
             m_background.enabled = enable;
         }
 
+        private ColorTransitionState GetColorStateForState()
+        {
+            if (IsPressed)
+            {
+                return m_ColorStates.pressed;
+            }
+            if (IsHighlighted)
+            {
+                return m_ColorStates.highlighted;
+            }
+            else
+            {
+                return m_ColorStates.normal;
+            }
+        }
+         
+        private void HandleStateChange()
+        {
+            ColorTransitionState newState = GetColorStateForState();
+            m_transition = GetTransitionFromCurrentTo(newState);
+            m_currentState = newState;
+        }
+
         public RoundedCubeBackground GetBackground()
         {
             return m_background;
@@ -179,22 +202,14 @@ namespace GTFO_VR.Core.UI.Terminal.Pointer
         public override void OnPointerEnter(PointerEvent ev)
         {
             IsHighlighted = true;
-            m_transition = GetTransitionFromCurrentTo(m_ColorStates.highlighted);
+            HandleStateChange();
         }
 
         [HideFromIl2Cpp]
         public override void OnPointerExit(PointerEvent ev)
         {
             IsHighlighted = false;
-            if (IsPressed)
-            {
-                m_currentState = m_ColorStates.pressed;
-            }
-            else
-            {
-                m_currentState = m_ColorStates.normal;
-                m_transition = GetTransitionFromCurrentTo(m_ColorStates.normal);
-            }
+            HandleStateChange();
         }
 
         [HideFromIl2Cpp]
@@ -210,16 +225,15 @@ namespace GTFO_VR.Core.UI.Terminal.Pointer
             m_keyRepeatDelta = 0;
             IsPressed = true;
             OnClick.Invoke();
-            m_transition = GetTransitionFromCurrentTo(m_ColorStates.pressed);
-            m_currentState = m_ColorStates.pressed;
+            HandleStateChange();
         }
 
         [HideFromIl2Cpp]
         public override void OnPointerUp(PointerEvent ev)
         {
             IsPressed = false;
-            m_transition = GetTransitionFromCurrentTo( IsHighlighted ? m_ColorStates.highlighted : m_ColorStates.normal);
-            m_currentState = IsHighlighted ? m_ColorStates.highlighted : m_ColorStates.normal;
+            HandleStateChange();
+
         }
 
         [HideFromIl2Cpp]

--- a/GTFO_VR/Core/UI/Terminal/Pointer/PhysicalButton.cs
+++ b/GTFO_VR/Core/UI/Terminal/Pointer/PhysicalButton.cs
@@ -80,7 +80,9 @@ namespace GTFO_VR.Core.UI.Terminal.Pointer
 
         public bool IsHighlighted = false;
         public bool IsPressed = false;
+        public bool IsToggled = false;
 
+        public bool ModifierKey = false;
         public bool RepeatKey = false;
         public float RepeatKeyTriggerTime = 0.5f;
         public float RepeatKeyDelay = 0.01f;
@@ -160,7 +162,7 @@ namespace GTFO_VR.Core.UI.Terminal.Pointer
 
         private ColorTransitionState GetColorStateForState()
         {
-            if (IsPressed)
+            if (IsPressed || IsToggled)
             {
                 return m_ColorStates.pressed;
             }
@@ -224,6 +226,8 @@ namespace GTFO_VR.Core.UI.Terminal.Pointer
             m_downDelta = 0;
             m_keyRepeatDelta = 0;
             IsPressed = true;
+            if (ModifierKey)
+                IsToggled = !IsToggled;
             OnClick.Invoke();
             HandleStateChange();
         }
@@ -233,7 +237,17 @@ namespace GTFO_VR.Core.UI.Terminal.Pointer
         {
             IsPressed = false;
             HandleStateChange();
+        }
 
+        [HideFromIl2Cpp]
+        public override void OnFocusLost(PointerEvent ev)
+        {
+            if (IsToggled)
+            {
+                IsToggled = false;
+                HandleStateChange();
+            }
+            
         }
 
         [HideFromIl2Cpp]

--- a/GTFO_VR/Core/UI/Terminal/Pointer/TerminalPointer.cs
+++ b/GTFO_VR/Core/UI/Terminal/Pointer/TerminalPointer.cs
@@ -158,11 +158,20 @@ namespace GTFO_VR.Core.UI.Terminal.Pointer
 
                 if (down)
                 {
+                    MonoPointerEvent prevDownButton = GetButton(m_ButtonPressHit);
                     
                     if ( button != null)
                     {
                         button.OnPointerDown(new PointerEvent(m_currentHit.point));
                         m_ButtonPressHit = m_currentHit;
+
+                        if ( prevDownButton != null && prevDownButton != button )
+                        {
+                            // This will clear any toggled state ( modifier ), but only visually in the button.
+                            // TerminalKeyboardInterface is responsible for clearing its own state after receiving the onclick of the button hit
+                            // Not because it's a good solution, but because it's easier.
+                            prevDownButton.OnFocusLost( new PointerEvent(Vector3.zero) );
+                        }
                     }
                 }
 
@@ -178,8 +187,6 @@ namespace GTFO_VR.Core.UI.Terminal.Pointer
                         button?.OnPointerUp( new PointerEvent(m_currentHit.point) );
 
                     }
-
-                    m_ButtonPressHit = new RaycastHit();
                 }
             }
         }

--- a/GTFO_VR/Core/UI/Terminal/TerminalKeyboardInterface.cs
+++ b/GTFO_VR/Core/UI/Terminal/TerminalKeyboardInterface.cs
@@ -468,7 +468,7 @@ namespace GTFO_VR.Core.UI.Terminal
                 keyboardRow.AddChild(new KeyDefinition("8").SetKeycode(KeyCode.Alpha8));
                 keyboardRow.AddChild(new KeyDefinition("9").SetKeycode(KeyCode.Alpha9));
                 keyboardRow.AddChild(new KeyDefinition("0").SetKeycode(KeyCode.Alpha0));
-                keyboardRow.AddChild(new KeyDefinition("."));   // For typing ip addresses
+                keyboardRow.AddChild(new KeyDefinition("["));
                 keyboardRow.AddChild(new KeyDefinition(KeyType.BACKPSPACE, "Backspace", new LayoutParameters( LayoutParameters.FILL_PARENT ))
                     .SetRepeatKey(true)
                     .SetApperance(KeyApperanceType.ALT));
@@ -496,7 +496,7 @@ namespace GTFO_VR.Core.UI.Terminal
                     keyboardRow.AddChild(new KeyDefinition("i").SetKeycode(KeyCode.I));
                     keyboardRow.AddChild(new KeyDefinition("o").SetKeycode(KeyCode.O));
                     keyboardRow.AddChild(new KeyDefinition("p").SetKeycode(KeyCode.P));
-                    keyboardRow.AddChild(new KeyDefinition("-"));
+                    keyboardRow.AddChild(new KeyDefinition("]"));
 
                     shortRowVertical.AddChild(keyboardRow);
                 }
@@ -518,7 +518,7 @@ namespace GTFO_VR.Core.UI.Terminal
                     keyboardRow.AddChild(new KeyDefinition("j").SetKeycode(KeyCode.J));
                     keyboardRow.AddChild(new KeyDefinition("k").SetKeycode(KeyCode.K));
                     keyboardRow.AddChild(new KeyDefinition("l").SetKeycode(KeyCode.L));
-                    keyboardRow.AddChild(new KeyDefinition("_"));
+                    keyboardRow.AddChild(new KeyDefinition("-"));
                     keyboardRow.AddChild(new KeyDefinition(KeyType.ENTER, "", new LayoutParameters(LayoutParameters.FILL_PARENT, 1, 0.01f))
                         .SetApperance(KeyApperanceType.GONE));
 
@@ -538,8 +538,8 @@ namespace GTFO_VR.Core.UI.Terminal
                     keyboardRow.AddChild(new KeyDefinition("b").SetKeycode(KeyCode.B));
                     keyboardRow.AddChild(new KeyDefinition("n").SetKeycode(KeyCode.N));
                     keyboardRow.AddChild(new KeyDefinition("m").SetKeycode(KeyCode.M));
-                    keyboardRow.AddChild(new KeyDefinition(","));
                     keyboardRow.AddChild(new KeyDefinition("."));
+                    keyboardRow.AddChild(new KeyDefinition("_"));
                     keyboardRow.AddChild(new KeyDefinition(KeyType.UP, "^", 1.1f)
                         .SetApperance(KeyApperanceType.ALT));
                     //keyboardRow.AddChild(new KeyDefinition(KeyType.EMPTY, "", new KeyboardLayoutParameters(1f, true)));

--- a/GTFO_VR/Core/UI/Terminal/TerminalReader.cs
+++ b/GTFO_VR/Core/UI/Terminal/TerminalReader.cs
@@ -150,7 +150,9 @@ namespace GTFO_VR.Core.UI.Terminal
             m_highlight.transform.localScale = new Vector3(width, lineHeight, 0.03f);
         }
 
-        private static HashSet<Char> DELIMITERS = new HashSet<char>() { '\'','\"', '\\', ' ', '\r', '\n', '\t', '\f', '\v', '<', '>', ',', '[', ']' };
+        private static HashSet<Char> DELIMITERS = new HashSet<char>() { '\'','\"', '\\', ' ', '\r', '\n', '\t', '\f', '\v', '<', '>', ','};
+
+        private static HashSet<Char> DELIMITERS_REQUIRE_SPACE = new HashSet<char>() { '[', ']' };
 
         public string GetSelection()
         {
@@ -202,9 +204,9 @@ namespace GTFO_VR.Core.UI.Terminal
             int indexStart = nearestOriginalIndex;
             int indexEnd = nearestOriginalIndex;
 
-            for (int i = nearestOriginalIndex; i < rawText.Length; i++ )
+            for (int i = nearestOriginalIndex; i < rawText.Length; i++)
             {
-                if (DELIMITERS.Contains(rawText[i]) )
+                if (DELIMITERS.Contains(rawText[i]))
                 {
                     break;
                 }
@@ -220,6 +222,15 @@ namespace GTFO_VR.Core.UI.Terminal
                 }
 
                 indexStart = i;
+            }
+            
+            // We delimit on [] because they sometimes surround stuff with them. 
+            // R7D1 introduces commands that contain brackets, like OVERRIDE_LOCKDOWN_ALPHA[CLASS_V]
+            // Do not delimit on [], but prune them if they are present at both the start and the end of the selection
+            if ( DELIMITERS_REQUIRE_SPACE.Contains(rawText[indexStart]) && DELIMITERS_REQUIRE_SPACE.Contains(rawText[indexEnd]) )
+            {
+                indexStart++;
+                indexEnd--;
             }
 
             // Same word, do nothing.

--- a/GTFO_VR/Injections/Input/InjectKeyInput.cs
+++ b/GTFO_VR/Injections/Input/InjectKeyInput.cs
@@ -21,4 +21,17 @@ namespace GTFO_VR.Injections.Input
         }
     }
 
+    /// <summary>
+    /// When checking for modifiers such as ctrl ( ctrl-c to cancel ping repeat ), GetKey() is queried instead
+    /// </summary>
+    ///
+    [HarmonyPatch(typeof(UnityEngine.Input), nameof(UnityEngine.Input.GetKey), typeof(UnityEngine.KeyCode))]
+    internal class InjectKey
+    {
+        private static void Postfix(KeyCode key, ref bool __result)
+        {
+            __result = __result || TerminalKeyboardInterface.GetKeycodeDown(key);
+        }
+    }
+
 }


### PR DESCRIPTION
### What

This PR 

- Fixes commands with `[brackets]` such a  `OVERRIDE_LOCKDOWN_ALPHA[CLASS_V]` in R7D1 delimiting on the `[ ]` brackets and therefore not being selectable as a single chunk of text
- Adds a `ctrl` button so you can perform `ctrl+c` to cancel terminal pings repeating with `-T`
- Adds `[` and `]` keys to the keyboard so that they can be input manually if desired.

 ### How

**[ Brackets ]**

We only delimit on `[ ]` because they sometimes surround words of interest with them. Fix is to not delimit on them initially, and then trim them if both the first and last characters of the selection is a `[ bracket ]`

**CTRL**

When pressed, `PhysicalButton`s with a `Modifier KeyType` set an internal `IsToggled` state that is represented in their color state. 
When pressed`TerminalKeyboardInterface` adds or removes the modifier to a `HashSet<KeyCode`, which is queried and cleared in `TerminalKeyboardInterface.LateUpdate()` if and only if a string or keycode input was presented that frame.
These modifiers are presented alongside other `KeyCode` input in `TerminalKeyboardInterface.GetKeycodeDown()`.
Modifier keys such as `ctrl` and `shift` are queried by `UnityEngine.Input.GetKey` instead of the existing `UnityEngine.Input.GetKeyDown` patch, so an additional patch was added for this.

If an input is received that corresponds to neither a `KeyCode` nor a `String input` (e.g. arrow keys, backspace, exit etc), we just clear the modifier `HashSet` immediately. 
Likewise, the button will clear its own `IsToggled` state if any other button is pressed.