### PR TITLE
Fix terminal issues caused by 2022-08-19 patch

### DIFF
--- a/GTFO_VR/Core/UI/Terminal/TerminalKeyboardInterface.cs
+++ b/GTFO_VR/Core/UI/Terminal/TerminalKeyboardInterface.cs
@@ -569,6 +569,7 @@ namespace GTFO_VR.Core.UI.Terminal
                     keyboardRow.AddChild(new KeyDefinition("."));
                     keyboardRow.AddChild(new KeyDefinition("_"));
                     keyboardRow.AddChild(new KeyDefinition(KeyType.UP, "^", 1.1f)
+                        .SetRepeatKey(true)
                         .SetKeycode(KeyCode.UpArrow)
                         .SetApperance(KeyApperanceType.ALT));
                     //keyboardRow.AddChild(new KeyDefinition(KeyType.EMPTY, "", new KeyboardLayoutParameters(1f, true)));
@@ -591,12 +592,15 @@ namespace GTFO_VR.Core.UI.Terminal
                     .SetApperance(KeyApperanceType.ALT));
                 keyboardRow.AddChild(new KeyDefinition(KeyType.SPACE, "Space", 7.2f));
                 keyboardRow.AddChild(new KeyDefinition(KeyType.LEFT, "<")
+                    .SetRepeatKey(true)
                     .SetKeycode(KeyCode.LeftArrow)
                     .SetApperance(KeyApperanceType.ALT));
                 keyboardRow.AddChild(new KeyDefinition(KeyType.DOWN, "v", 1.1f)
+                    .SetRepeatKey(true)
                     .SetKeycode(KeyCode.DownArrow)
                     .SetApperance(KeyApperanceType.ALT));
                 keyboardRow.AddChild(new KeyDefinition(KeyType.RIGHT, ">")
+                    .SetRepeatKey(true)
                     .SetKeycode(KeyCode.RightArrow)
                     .SetApperance(KeyApperanceType.ALT));
                 keyboardRow.AddChild(new KeyDefinition(KeyType.ESC, "x", new LayoutParameters(LayoutParameters.FILL_PARENT))

--- a/GTFO_VR/Core/UI/Terminal/TerminalKeyboardInterface.cs
+++ b/GTFO_VR/Core/UI/Terminal/TerminalKeyboardInterface.cs
@@ -569,6 +569,7 @@ namespace GTFO_VR.Core.UI.Terminal
                     keyboardRow.AddChild(new KeyDefinition("."));
                     keyboardRow.AddChild(new KeyDefinition("_"));
                     keyboardRow.AddChild(new KeyDefinition(KeyType.UP, "^", 1.1f)
+                        .SetKeycode(KeyCode.UpArrow)
                         .SetApperance(KeyApperanceType.ALT));
                     //keyboardRow.AddChild(new KeyDefinition(KeyType.EMPTY, "", new KeyboardLayoutParameters(1f, true)));
 
@@ -590,12 +591,16 @@ namespace GTFO_VR.Core.UI.Terminal
                     .SetApperance(KeyApperanceType.ALT));
                 keyboardRow.AddChild(new KeyDefinition(KeyType.SPACE, "Space", 7.2f));
                 keyboardRow.AddChild(new KeyDefinition(KeyType.LEFT, "<")
+                    .SetKeycode(KeyCode.LeftArrow)
                     .SetApperance(KeyApperanceType.ALT));
                 keyboardRow.AddChild(new KeyDefinition(KeyType.DOWN, "v", 1.1f)
+                    .SetKeycode(KeyCode.DownArrow)
                     .SetApperance(KeyApperanceType.ALT));
                 keyboardRow.AddChild(new KeyDefinition(KeyType.RIGHT, ">")
+                    .SetKeycode(KeyCode.RightArrow)
                     .SetApperance(KeyApperanceType.ALT));
                 keyboardRow.AddChild(new KeyDefinition(KeyType.ESC, "x", new LayoutParameters(LayoutParameters.FILL_PARENT))
+                    .SetKeycode(KeyCode.Escape)
                     .SetApperance(KeyApperanceType.EXIT));
 
                 bottomKeyboardLayout.AddChild(keyboardRow);

--- a/GTFO_VR/Core/UI/Terminal/TerminalKeyboardInterface.cs
+++ b/GTFO_VR/Core/UI/Terminal/TerminalKeyboardInterface.cs
@@ -308,12 +308,6 @@ namespace GTFO_VR.Core.UI.Terminal
             {
                 switch(key.KeyType)
                 {
-                    case KeyType.BACKPSPACE:
-                    {
-                        Dummy_InputHandler.triggerDummyAction(InputAction.TerminalDel);
-                        break;
-                    }
-
                     case KeyType.ESC:
                     {
                         Dummy_InputHandler.triggerDummyAction(InputAction.TerminalExit);
@@ -502,7 +496,8 @@ namespace GTFO_VR.Core.UI.Terminal
                 keyboardRow.AddChild(new KeyDefinition("9").SetKeycode(KeyCode.Alpha9));
                 keyboardRow.AddChild(new KeyDefinition("0").SetKeycode(KeyCode.Alpha0));
                 keyboardRow.AddChild(new KeyDefinition("["));
-                keyboardRow.AddChild(new KeyDefinition(KeyType.BACKPSPACE, "Backspace", new LayoutParameters( LayoutParameters.FILL_PARENT ))
+                keyboardRow.AddChild(new KeyDefinition("\u0008", "Backspace", new LayoutParameters( LayoutParameters.FILL_PARENT ))
+                    .SetKeycode(KeyCode.Backspace)
                     .SetRepeatKey(true)
                     .SetApperance(KeyApperanceType.ALT));
 

--- a/GTFO_VR/Core/VR_Input/Dummy_InputHandler.cs
+++ b/GTFO_VR/Core/VR_Input/Dummy_InputHandler.cs
@@ -147,7 +147,6 @@ namespace GTFO_VR.Core.VR_Input
         {
             dummyBoolActions = new Dictionary<InputAction, DummyAction>
             {
-                { InputAction.TerminalDel, m_terminalDeleteAction },
                 { InputAction.TerminalExit, m_terminalExitAction },
 
                 { InputAction.TerminalLeft, m_terminalLeftAction },


### PR DESCRIPTION
### What & How

This PR fixes some issues with the terminal keyboard introduced by the 2022-08-19 patch.

**Problem # 1:** Keyboard stops responding ( except for exit button ) after hitting `backspace` or the `arrow` keys.

`Dummy_InputHandler`, responsible for actions triggered by the keyboards such as `InputAction.TerminalDel` and `InputAction.TerminalUp` assumed that `getDown()` would be called before `getState()` or `getUp()`, or at least called at *some* point.

As of the patch, only `getState()` and `getUp()` are queried for these `InputAction`s, resulting in the key being stuck in a down state, breaking the rest of the keyboard.

This was fixed by moving the figure-out-what-the-states-should-be logic to a single shared `DummyAction.Evaluate()` that is run regardless of whether `getDown()`, `getUp()`, or `getState()` is called.

**Problem # 2:** The Backspace button doesn't actually do anything anymore.

After fixing the above problem the keyboard no longer breaks, and the arrow keys that also rely on `InputAction`s work correctly, but, despite being queried, the Backspace key does not actually do anything.

Most likely they moved some logic around and this is now a text input instead of an `InputAction`, though I haven't decompiled it to confirm.

Solved by having the Backspace button input a `\u0008` Backspace character instead of triggering `InputAction.TerminalDel`

**Other changes**
In addition to these changes, `Dummy_InputHandler` now defaults to holding the key down for 5 frames before releasing it, instead of a single frame, and `Backspace`, `ESC`, and all the `Arrow` keys now also trigger their corresponding `KeyCode`.

This may or may not fix a very rare issue where `Exit` button on the keyboard will not exit the terminal, and you have to use `reload/dismiss` instead.
