### PR TITLE
Fix R5 gun sights ( Accrat ND6 Heavy SMG )

### DIFF
--- a/GTFO_VR/Injections/Gameplay/InjectMuzzleAlignCorrection.cs
+++ b/GTFO_VR/Injections/Gameplay/InjectMuzzleAlignCorrection.cs
@@ -1,0 +1,37 @@
+﻿using HarmonyLib;
+using UnityEngine;
+using Gear;
+
+
+namespace GTFO_VR.Injections.Gameplay
+{
+    /// <summary>
+    /// Adjust the muzzle align to be where it should be on certain broken weapons
+    /// </summary>
+    [HarmonyPatch(typeof(BulletWeapon), nameof(BulletWeapon.SetupArchetype))]
+    internal class InjectMuzzleAlignCorrection
+    {
+        private static void Postfix(BulletWeapon __instance)
+        {
+            // Accrat ND6 Heavy SMG
+            if ("ACCRAT ND6".Equals(__instance.PublicName.ToUpper()))
+            {
+                Transform muzzleAlign = __instance.MuzzleAlign;
+                Transform animationRef = muzzleAlign.parent; // This is keyframed with an incorrect rotation, 
+                                                             // so we can't just adjust it directly
+
+                // Put muzzle align in a container positioned at origin of parent
+                GameObject muzzleContainer = new GameObject("muzzleContainer");
+                muzzleContainer.transform.SetParentAtZero(animationRef);
+                muzzleAlign.transform.SetParent(muzzleContainer.transform);
+
+                // Apply inverse rotation of parent to align muzzle
+                muzzleContainer.transform.localRotation = Quaternion.Inverse(animationRef.transform.localRotation);
+
+                // Move container to parent so it doesn't get moved by animations
+                muzzleContainer.transform.SetParent(animationRef.transform.parent);
+            }
+            
+        }
+    }
+}

--- a/GTFO_VR/Injections/Rendering/InjectFPRendering.cs
+++ b/GTFO_VR/Injections/Rendering/InjectFPRendering.cs
@@ -103,9 +103,7 @@ namespace GTFO_VR.Injections.Rendering
 
         private static void Prefix(ref bool enable, GameObject go)
         {
-            
-
-            // This probably only needs to be run once for each unique GO, but I'm not going to be the one to break it.
+            // This hook is only called once for each GO
             foreach (var m in go.GetComponentsInChildren<MeshRenderer>(true))
             {
                 if (m == null || m.sharedMaterials == null)
@@ -146,6 +144,34 @@ namespace GTFO_VR.Injections.Rendering
                             {
                                 // And enabling it makes most of them at least usable
                                 mat.EnableKeyword("ALTERNATIVE_PROJECTION_MODE");
+
+                                // Accrat ND6 Heavy SMG
+                                if (mat.name.Equals("Sight_2_1"))
+                                {
+                                    // The muzzle is also misaligned
+                                    // This is corrected in InjectMuzzleAlignCorrection
+
+                                    mat.SetFloat("_ProjSize1", 0.6f);
+                                    mat.SetFloat("_ProjSize2", 0.2f);
+                                    mat.SetFloat("_ProjSize3", 0.6f);
+
+                                    mat.SetFloat("_ProjDist1", 100);
+                                    mat.SetFloat("_ProjDist2", 20);
+                                    mat.SetFloat("_ProjDist3", 5);
+
+                                    mat.SetFloat("_ZeroOffset", 0.25f);
+
+                                    // Tune down the dirt so you're not blinded
+                                    mat.SetFloat("_SightDirt", 1);
+
+                                    // Reticle is basically invisible unless completely center because of how it blends with the sight.
+                                    // Make it glow like a dotsight should.
+                                    float sightGlowMultiplier = 9;
+                                    float SlightsightGlowMultiplier = 3;
+                                    mat.SetColor("_ReticuleColorA", new Color(0, sightGlowMultiplier, 0.7935257f * sightGlowMultiplier, 1f));
+                                    mat.SetColor("_ReticuleColorB", new Color(0, SlightsightGlowMultiplier, 0.7935257f * SlightsightGlowMultiplier, 1f));
+                                    mat.SetColor("_ReticuleColorC", new Color(0, SlightsightGlowMultiplier, 0.7935257f * SlightsightGlowMultiplier, 1f));
+                                }
 
                                 // Techman Klaust 6 Burst Cannon
                                 if (mat.name.Equals("Sight_9_1"))


### PR DESCRIPTION
## What

Fixes the sight of Accrat ND6 Heavy SMG

In addition to the sight being messed up as usual, the gun has animations that incorrectly rotate `weapon_animation_ref` containing the `muzzle align`, resulting in the sight not aligning with the laser and fired bullets. 

![nd6_broken_sight](https://github.com/DSprtn/GTFO_VR_Plugin/assets/8961771/e1eaf653-58fa-455f-9e04-202a3b28212c)

## How

`ALTERNATIVE_PROJECTION_MODE` keyword enabled on material as usual, material parameters tweaked to make it look right.

`Muzzle align` was moved to a container with the inverse rotation of `weapon_animation_ref` to realign the muzzle, and then moved out of `weapon_animation_ref` so it won't be affected by the animation moving it around.
This task is performed once in a new hook hooking `BulletWeapon.SetupArchetype`, chosen because everything seems to be set up at that point.

[Gtfo Nd6.webm](https://github.com/DSprtn/GTFO_VR_Plugin/assets/8961771/6393b61d-79b5-46d7-a3ee-d471ceffbaad)
