### PR TITLE
Shockwave haptics setting

### DIFF
--- a/GTFO_VR/Core/PlayerBehaviours/BodyHaptics/Bhaptics/BhapticsElevatorSequence.cs
+++ b/GTFO_VR/Core/PlayerBehaviours/BodyHaptics/Bhaptics/BhapticsElevatorSequence.cs
@@ -81,7 +81,8 @@ namespace GTFO_VR.Core.PlayerBehaviours.BodyHaptics.Bhaptics
 
         private void ResubmitCompletedHapticPatterns()
         {
-            if (!VRConfig.configUseBhaptics.Value)
+            // If inactive, just skip submitting the next pattern.
+            if (!AgentActive())
             {
                 return;
             }
@@ -209,6 +210,11 @@ namespace GTFO_VR.Core.PlayerBehaviours.BodyHaptics.Bhaptics
                 FeedbackDurationScale = feedbackDurationScale;
                 FeedbackIntensity = feedbackIntensity;
             }
+        }
+
+        public bool AgentActive()
+        {
+            return VRConfig.configUseBhaptics.Value;
         }
     }
 }

--- a/GTFO_VR/Core/PlayerBehaviours/BodyHaptics/Bhaptics/BhapticsIntegration.cs
+++ b/GTFO_VR/Core/PlayerBehaviours/BodyHaptics/Bhaptics/BhapticsIntegration.cs
@@ -516,5 +516,9 @@ namespace GTFO_VR.Core.PlayerBehaviours.BodyHaptics.Bhaptics
                 m_hapticPlayer.SubmitRegistered(VEST_STAND_KEY);
             }
         }
+        public bool AgentActive()
+        {
+            return VRConfig.configUseBhaptics.Value;
+        }
     }
 }

--- a/GTFO_VR/Core/PlayerBehaviours/BodyHaptics/Bhaptics/BhapticsIntegration.cs
+++ b/GTFO_VR/Core/PlayerBehaviours/BodyHaptics/Bhaptics/BhapticsIntegration.cs
@@ -126,7 +126,7 @@ namespace GTFO_VR.Core.PlayerBehaviours.BodyHaptics.Bhaptics
 
         public void Update()
         {
-            if (VRConfig.configUseBhaptics.Value)
+            if (AgentActive())
             {
                 UpdateBhapticsState();
             }
@@ -167,7 +167,7 @@ namespace GTFO_VR.Core.PlayerBehaviours.BodyHaptics.Bhaptics
 
         public void HammerSmackHaptics(float dmg)
         {
-            if (!VRConfig.configUseBhaptics.Value)
+            if (!AgentActive())
             {
                 return;
             }
@@ -186,7 +186,7 @@ namespace GTFO_VR.Core.PlayerBehaviours.BodyHaptics.Bhaptics
 
         public void HammerFullyChargedHaptics()
         {
-            if (!VRConfig.configUseBhaptics.Value)
+            if (!AgentActive())
             {
                 return;
             }
@@ -205,7 +205,7 @@ namespace GTFO_VR.Core.PlayerBehaviours.BodyHaptics.Bhaptics
 
         public void HammerChargingHaptics(float pressure)
         {
-            if (!VRConfig.configUseBhaptics.Value)
+            if (!AgentActive())
             {
                 return;
             }
@@ -226,7 +226,7 @@ namespace GTFO_VR.Core.PlayerBehaviours.BodyHaptics.Bhaptics
 
         public void PlayWeaponReloadHaptics()
         {
-            if (!VRConfig.configUseBhaptics.Value)
+            if (!AgentActive())
             {
                 return;
             }
@@ -245,7 +245,7 @@ namespace GTFO_VR.Core.PlayerBehaviours.BodyHaptics.Bhaptics
 
         public void PlayWeaponFireHaptics(Weapon weapon)
         {
-            if (!VRConfig.configUseBhaptics.Value)
+            if (!AgentActive())
             {
                 return;
             }
@@ -279,7 +279,7 @@ namespace GTFO_VR.Core.PlayerBehaviours.BodyHaptics.Bhaptics
 
         public void PlayReceiveDamageHaptics(float dmg, Vector3 direction)
         {
-            if (!VRConfig.configUseBhaptics.Value)
+            if (!AgentActive())
             {
                 return;
             }
@@ -297,7 +297,7 @@ namespace GTFO_VR.Core.PlayerBehaviours.BodyHaptics.Bhaptics
 
         public void MineExplosionHaptics(OrientationSettings orientationSettings, float intensity)
         {
-            if (!VRConfig.configUseBhaptics.Value)
+            if (!AgentActive())
             {
                 return;
             }
@@ -311,7 +311,7 @@ namespace GTFO_VR.Core.PlayerBehaviours.BodyHaptics.Bhaptics
 
         public void TentacleAttackHaptics(float dmg, Agents.Agent sourceAgent, Vector3 position)
         {
-            if (!VRConfig.configUseBhaptics.Value || sourceAgent != m_player)
+            if (!AgentActive() || sourceAgent != m_player)
             {
                 return;
             }
@@ -330,7 +330,7 @@ namespace GTFO_VR.Core.PlayerBehaviours.BodyHaptics.Bhaptics
 
         public void LandedFromElevator(eFocusState focusState)
         {
-            if (!VRConfig.configUseBhaptics.Value)
+            if (!AgentActive())
             {
                 return;
             }
@@ -341,7 +341,7 @@ namespace GTFO_VR.Core.PlayerBehaviours.BodyHaptics.Bhaptics
 
         public void PlayerInteractedHaptics(PlayerAgent source)
         {
-            if (!VRConfig.configUseBhaptics.Value || (source != null && source != m_player))
+            if (!AgentActive() || (source != null && source != m_player))
             {
                 return;
             }
@@ -358,7 +358,7 @@ namespace GTFO_VR.Core.PlayerBehaviours.BodyHaptics.Bhaptics
 
         public void PlayBioscanHaptics()
         {
-            if (!VRConfig.configUseBhaptics.Value)
+            if (!AgentActive())
             {
                 return;
             }
@@ -377,7 +377,7 @@ namespace GTFO_VR.Core.PlayerBehaviours.BodyHaptics.Bhaptics
 
         public void FlashlightToggledHaptics()
         {
-            if (!VRConfig.configUseBhaptics.Value || !m_player.Alive)
+            if (!AgentActive() || !m_player.Alive)
             {
                 return;
             }
@@ -394,7 +394,7 @@ namespace GTFO_VR.Core.PlayerBehaviours.BodyHaptics.Bhaptics
 
         public void PlayerChangedItemHaptics(ItemEquippable item)
         {
-            if (!VRConfig.configUseBhaptics.Value)
+            if (!AgentActive())
             {
                 return;
             }
@@ -413,7 +413,7 @@ namespace GTFO_VR.Core.PlayerBehaviours.BodyHaptics.Bhaptics
 
         public void AmmoGainedHaptics(float ammoStandardRel, float ammoSpecialRel, float ammoClassRel)
         {
-            if (!VRConfig.configUseBhaptics.Value)
+            if (!AgentActive())
             {
                 return;
             }
@@ -432,7 +432,7 @@ namespace GTFO_VR.Core.PlayerBehaviours.BodyHaptics.Bhaptics
 
         public void InfectionHealed(float infection)
         {
-            if (!VRConfig.configUseBhaptics.Value)
+            if (!AgentActive())
             {
                 return;
             }
@@ -442,7 +442,7 @@ namespace GTFO_VR.Core.PlayerBehaviours.BodyHaptics.Bhaptics
 
         public void OnHealthUpdated(float health)
         {
-            if (VRConfig.configUseBhaptics.Value)
+            if (AgentActive())
             {
                 if (health <= BodyHapticsUtils.LOW_HEALTH && m_nextHeartbeatPatternTime <= 0)
                 {
@@ -486,7 +486,7 @@ namespace GTFO_VR.Core.PlayerBehaviours.BodyHaptics.Bhaptics
 
         public void OnPlayerLocomotionStateChanged(PlayerLocomotion.PLOC_State state)
         {
-            if (!VRConfig.configUseBhaptics.Value)
+            if (!AgentActive())
             {
                 return;
             }
@@ -502,7 +502,7 @@ namespace GTFO_VR.Core.PlayerBehaviours.BodyHaptics.Bhaptics
 
         public void CrouchToggleHaptics(bool isCrouched)
         {
-            if (!VRConfig.configUseBhaptics.Value || m_lastLocState == PlayerLocomotion.PLOC_State.InElevator)
+            if (!AgentActive() || m_lastLocState == PlayerLocomotion.PLOC_State.InElevator)
             {
                 return;
             }

--- a/GTFO_VR/Core/PlayerBehaviours/BodyHaptics/BodyHapticAgent.cs
+++ b/GTFO_VR/Core/PlayerBehaviours/BodyHaptics/BodyHapticAgent.cs
@@ -5,6 +5,7 @@ namespace GTFO_VR.Core.PlayerBehaviours.BodyHaptics
 {
     public interface BodyHapticAgent
     {
+        bool AgentActive();
         void Update();
         void HammerSmackHaptics(float dmg);
         void HammerFullyChargedHaptics();

--- a/GTFO_VR/Core/PlayerBehaviours/BodyHaptics/BodyHapticsIntegrator.cs
+++ b/GTFO_VR/Core/PlayerBehaviours/BodyHaptics/BodyHapticsIntegrator.cs
@@ -48,12 +48,36 @@ namespace GTFO_VR.Core.PlayerBehaviours.BodyHaptics
 
         public static void Initialize()
         {
-            ShockwaveManager.Instance.InitializeSuit();
+            // This component is not awake until cagedrop, and we want to be able to toggle this before then.
+            // Initialize() is only called once per run.
+            VRConfig.configUseShockwave.SettingChanged += shockwaveConfigChanged;
+
+            InitializeShockwave();
+        }
+
+        private static void InitializeShockwave()
+        {
+            // Initialize if enabled and not already initialized
+            if (VRConfig.configUseShockwave.Value && !ShockwaveManager.Instance.Ready)
+            {
+                Log.Info("Initializing Shockwave suit");
+                ShockwaveManager.Instance.InitializeSuit();
+            }
         }
 
         public static void Destroy()
         {
             ShockwaveManager.Instance.DisconnectSuit();
+        }
+
+        private static void shockwaveConfigChanged(object sender, EventArgs e)
+        {
+            // Initialize if enabled after initial launch.
+            // I could not find any documentation, so safest to just leave connected even if disabled later.
+            if (VRConfig.configUseShockwave.Value)
+            {
+                InitializeShockwave();
+            }
         }
 
         private void Awake()

--- a/GTFO_VR/Core/PlayerBehaviours/BodyHaptics/ElevatorSequenceAgent.cs
+++ b/GTFO_VR/Core/PlayerBehaviours/BodyHaptics/ElevatorSequenceAgent.cs
@@ -2,6 +2,7 @@
 {
     public interface ElevatorSequenceAgent
     {
+        bool AgentActive();
         void Update();
         void ElevatorStateChanged(ElevatorState elevatorState);
         void SetIsInElevator(bool inElevator);

--- a/GTFO_VR/Core/PlayerBehaviours/BodyHaptics/Shockwave/ShockwaveElevatorSequence.cs
+++ b/GTFO_VR/Core/PlayerBehaviours/BodyHaptics/Shockwave/ShockwaveElevatorSequence.cs
@@ -21,6 +21,13 @@ namespace GTFO_VR.Core.PlayerBehaviours.BodyHaptics.Shockwave
         {
             m_elevatorState = elevatorState;
 
+            // If not active update state so any while() loops below are exited,
+            // but don't trigger nay new patterns
+            if (!AgentActive())
+            {
+                return;
+            }
+
             if (elevatorState == ElevatorState.FirstMovement
                 || elevatorState == ElevatorState.CageRotating)
             {
@@ -178,6 +185,11 @@ namespace GTFO_VR.Core.PlayerBehaviours.BodyHaptics.Shockwave
             List<List<int>> listIndices = BodyHapticsIndices.FeetToShoulders;
             int duration = 2000 / listIndices.Count;
             await ShockwaveEngine.PlayPatternFunc(new HapticIndexPattern(listIndices, 0.7f, duration));
+        }
+
+        public bool AgentActive()
+        {
+            return VRConfig.configUseShockwave.Value && ShockwaveManager.Instance.Ready && ShockwaveManager.Instance.suitConnected();
         }
     }
 }

--- a/GTFO_VR/Core/PlayerBehaviours/BodyHaptics/Shockwave/ShockwaveIntegration.cs
+++ b/GTFO_VR/Core/PlayerBehaviours/BodyHaptics/Shockwave/ShockwaveIntegration.cs
@@ -41,6 +41,11 @@ namespace GTFO_VR.Core.PlayerBehaviours.BodyHaptics.Shockwave
 
         public void HammerSmackHaptics(float dmg)
         {
+            if (!AgentActive())
+            {
+                return;
+            }
+
             List<List<int>> rightIndices = new List<List<int>>
             {
                 new List<int>{ 54, 55 },
@@ -64,6 +69,11 @@ namespace GTFO_VR.Core.PlayerBehaviours.BodyHaptics.Shockwave
 
         public void HammerFullyChargedHaptics()
         {
+            if (!AgentActive())
+            {
+                return;
+            }
+
             List<List<int>> rightIndices = new List<List<int>>
             {
                 new List<int>{ 54 },
@@ -85,6 +95,11 @@ namespace GTFO_VR.Core.PlayerBehaviours.BodyHaptics.Shockwave
 
         public void HammerChargingHaptics(float pressure)
         {
+            if (!AgentActive())
+            {
+                return;
+            }       
+
             if (IsInElevator())
             {
                 return;
@@ -97,6 +112,11 @@ namespace GTFO_VR.Core.PlayerBehaviours.BodyHaptics.Shockwave
 
         private async void PlayWeaponReloadHapticsFunc()
         {
+            if (!AgentActive())
+            {
+                return;
+            }
+
             const int delay = 150;
 
             int[] rightArmIndices = { 54, 52, 50, 51, 53, 55 };
@@ -122,6 +142,12 @@ namespace GTFO_VR.Core.PlayerBehaviours.BodyHaptics.Shockwave
         public void PlayWeaponReloadHaptics()
         {
             m_isReloading = true;
+
+            if (!AgentActive())
+            {
+                return;
+            }
+
             PlayWeaponReloadHapticsFunc();
         }
 
@@ -132,6 +158,11 @@ namespace GTFO_VR.Core.PlayerBehaviours.BodyHaptics.Shockwave
 
         public void PlayWeaponFireHaptics(Weapon weapon)
         {
+            if (!AgentActive())
+            {
+                return;
+            }
+
             float intensity = Haptics.GetFireHapticStrength(weapon);
 
             if (Controllers.MainControllerType == HandType.Left || Controllers.AimingTwoHanded)
@@ -162,12 +193,23 @@ namespace GTFO_VR.Core.PlayerBehaviours.BodyHaptics.Shockwave
         public void PlayReceiveDamageHaptics(float dmg, Vector3 direction)
         {
             OrientationSettings orientationSettings = BodyHapticsUtils.GetOrientationSettingsFromDirection(m_player, direction);
-            SendOrientedHapticPulse(ShockwaveManager.HapticRegion.TORSO, 1, 10, 50, orientationSettings);
             m_lastDamageOrientationSettings = orientationSettings;
+
+            if (!AgentActive())
+            {
+                return;
+            }
+
+            SendOrientedHapticPulse(ShockwaveManager.HapticRegion.TORSO, 1, 10, 50, orientationSettings);
         }
 
         private void SendTorsoOrientedHaptic(float offsetAngleX, float offsetY, float strength = 1f, int duration = 150)
         {
+            if (!AgentActive())
+            {
+                return;
+            }
+
             const int regionHeight = 10;
             SendOrientedHapticPulse(ShockwaveManager.HapticRegion.TORSO, strength, regionHeight, duration,
                 new OrientationSettings(offsetAngleX, offsetY));
@@ -175,6 +217,11 @@ namespace GTFO_VR.Core.PlayerBehaviours.BodyHaptics.Shockwave
 
         public async void MineExplosionHaptics(OrientationSettings orientation, float intensity)
         {
+            if (!AgentActive())
+            {
+                return;
+            }
+
             const float offsetYStep = 0.2f;
             const float offsetAngleXStep = 45f;
             const int range = 3;
@@ -210,6 +257,11 @@ namespace GTFO_VR.Core.PlayerBehaviours.BodyHaptics.Shockwave
 
         public async void TentacleAttackHaptics(float dmg, Agent sourceAgent, Vector3 position)
         {
+            if (!AgentActive())
+            {
+                return;
+            }
+
             if (m_lastDamageOrientationSettings != null)
             {
                 const float offsetYStep = 0.2f;
@@ -233,12 +285,22 @@ namespace GTFO_VR.Core.PlayerBehaviours.BodyHaptics.Shockwave
 
         public async void LandedFromElevator(eFocusState focusState)
         {
+            if (!AgentActive())
+            {
+                return;
+            }
+
             await Task.Delay(500);
             ShockwaveEngine.PlayPattern(new HapticIndexPattern(BodyHapticsIndices.FeetToShoulders, 1f, 30));
         }
 
         public void PlayerInteractedHaptics(PlayerAgent source)
         {
+            if (!AgentActive())
+            {
+                return;
+            }
+
             int[] rightArmIndices = { 54, 55 };
             int[] indices = (Controllers.MainControllerType == HandType.Left) ? ShockwaveEngine.GetPatternMirror(rightArmIndices) : rightArmIndices;
             ShockwaveEngine.PlayPattern(new HapticIndexPattern(indices, 0.6f, 25));
@@ -246,6 +308,11 @@ namespace GTFO_VR.Core.PlayerBehaviours.BodyHaptics.Shockwave
 
         private async void PlayBioscanPatternFunc()
         {
+            if (!AgentActive())
+            {
+                return;
+            }
+
             List<List<int>> RightToLeft = new List<List<int>>
             {
                 new List<int>{ 54, 52, 50, 48, 55, 53, 51, 49 },
@@ -284,6 +351,12 @@ namespace GTFO_VR.Core.PlayerBehaviours.BodyHaptics.Shockwave
         public void PlayBioscanHaptics()
         {
             m_isBioScanning = true;
+
+            if (!AgentActive())
+            {
+                return;
+            }
+
             PlayBioscanPatternFunc();
         }
 
@@ -294,6 +367,11 @@ namespace GTFO_VR.Core.PlayerBehaviours.BodyHaptics.Shockwave
 
         public void FlashlightToggledHaptics()
         {
+            if (!AgentActive())
+            {
+                return;
+            }
+
             int[] rightArmIndices = { 54 };
             int[] indices = (Controllers.MainControllerType == HandType.Left) ? ShockwaveEngine.GetPatternMirror(rightArmIndices) : rightArmIndices;
             ShockwaveEngine.PlayPattern(new HapticIndexPattern(indices, 0.6f, 25));
@@ -313,6 +391,11 @@ namespace GTFO_VR.Core.PlayerBehaviours.BodyHaptics.Shockwave
 
         public void PlayerChangedItemHaptics(ItemEquippable item)
         {
+            if (!AgentActive())
+            {
+                return;
+            }
+
             if (IsInElevator())
             {
                 return;
@@ -330,6 +413,11 @@ namespace GTFO_VR.Core.PlayerBehaviours.BodyHaptics.Shockwave
 
         private void PlayGainAmmoPattern()
         {
+            if (!AgentActive())
+            {
+                return;
+            }
+
             const float intensity = 0.7f;
             const int delay = 300;
 
@@ -364,6 +452,11 @@ namespace GTFO_VR.Core.PlayerBehaviours.BodyHaptics.Shockwave
 
         private async void PlayGainToolsPattern()
         {
+            if (!AgentActive())
+            {
+                return;
+            }
+
             const float intensity = 0.7f;
 
             for (int i = 0; i < 2; i++)
@@ -400,6 +493,11 @@ namespace GTFO_VR.Core.PlayerBehaviours.BodyHaptics.Shockwave
 
         public void AmmoGainedHaptics(float ammoStandardRel, float ammoSpecialRel, float ammoClassRel)
         {
+            if (!AgentActive())
+            {
+                return;
+            }
+
             if (ammoStandardRel > 0 || ammoSpecialRel > 0)
             {
                 PlayGainAmmoPattern();
@@ -412,6 +510,11 @@ namespace GTFO_VR.Core.PlayerBehaviours.BodyHaptics.Shockwave
 
         public async void InfectionHealed(float infection)
         {
+            if (!AgentActive())
+            {
+                return;
+            }
+
             int[] indices = {
                 6, 14, 22, 30, 38, 39, 31, 23, 15, 7, 0, 8, 16, 24, 32, 33, 25, 17, 9, 1,
                 2, 10, 18, 26, 34, 35, 27, 19, 11, 3, 4, 12, 20, 28, 36, 37, 29, 21, 13, 5
@@ -431,6 +534,11 @@ namespace GTFO_VR.Core.PlayerBehaviours.BodyHaptics.Shockwave
 
         private async void PlayLifeGainPattern()
         {
+            if (!AgentActive())
+            {
+                return;
+            }
+
             const int bodyPointsCount = 40;
             int[] indices = new int[bodyPointsCount];
             for (int i = 0; i < bodyPointsCount; i++)
@@ -448,6 +556,11 @@ namespace GTFO_VR.Core.PlayerBehaviours.BodyHaptics.Shockwave
 
         private async void PlayHeartbeatPattern()
         {
+            if (!AgentActive())
+            {
+                return;
+            }
+
             const float VERY_LOW_HEALTH = 0.10f;
 
             while (m_isLowHealth)
@@ -476,6 +589,11 @@ namespace GTFO_VR.Core.PlayerBehaviours.BodyHaptics.Shockwave
 
         private void PlayDeathPattern()
         {
+            if (!AgentActive())
+            {
+                return;
+            }
+
             ShockwaveEngine.PlayPattern(new HapticIndexPattern(BodyHapticsIndices.ShouldersToFeet, 1.0f, 40));
         }
 
@@ -515,6 +633,11 @@ namespace GTFO_VR.Core.PlayerBehaviours.BodyHaptics.Shockwave
 
         public async void WeaponAmmoEmpty(bool leftArm)
         {
+            if (!AgentActive())
+            {
+                return;
+            }
+
             if (IsInElevator())
             {
                 return;
@@ -528,19 +651,22 @@ namespace GTFO_VR.Core.PlayerBehaviours.BodyHaptics.Shockwave
 
         public void OnPlayerLocomotionStateChanged(PlayerLocomotion.PLOC_State state)
         {
-            if ((m_lastLocState == PlayerLocomotion.PLOC_State.Fall || m_lastLocState == PlayerLocomotion.PLOC_State.Jump)
-                && (state == PlayerLocomotion.PLOC_State.Stand || state == PlayerLocomotion.PLOC_State.Crouch))
+            if (AgentActive())
             {
-                var indices = new List<List<int>>
+                if ((m_lastLocState == PlayerLocomotion.PLOC_State.Fall || m_lastLocState == PlayerLocomotion.PLOC_State.Jump)
+                    && (state == PlayerLocomotion.PLOC_State.Stand || state == PlayerLocomotion.PLOC_State.Crouch))
                 {
-                    new List<int>{ 8, 9, 10, 11, 12, 13, 14, 15 },
-                    new List<int>{ 0, 1, 2, 3, 4, 5, 6, 7 },
-                    new List<int>{ 64, 56, 57, 65 },
-                    new List<int>{ 66, 58, 59, 67 },
-                    new List<int>{ 68, 60, 61, 69 },
-                    new List<int>{ 70, 62, 63, 71 },
-                };
-                ShockwaveEngine.PlayPattern(new HapticIndexPattern(indices, 0.4f, 25));
+                    var indices = new List<List<int>>
+                    {
+                        new List<int>{ 8, 9, 10, 11, 12, 13, 14, 15 },
+                        new List<int>{ 0, 1, 2, 3, 4, 5, 6, 7 },
+                        new List<int>{ 64, 56, 57, 65 },
+                        new List<int>{ 66, 58, 59, 67 },
+                        new List<int>{ 68, 60, 61, 69 },
+                        new List<int>{ 70, 62, 63, 71 },
+                    };
+                    ShockwaveEngine.PlayPattern(new HapticIndexPattern(indices, 0.4f, 25));
+                }
             }
 
             m_lastLocState = state;
@@ -548,6 +674,11 @@ namespace GTFO_VR.Core.PlayerBehaviours.BodyHaptics.Shockwave
 
         public void CrouchToggleHaptics(bool isCrouched)
         {
+            if (!AgentActive())
+            {
+                return;
+            }
+
             if (IsInElevator())
             {
                 return;
@@ -578,6 +709,11 @@ namespace GTFO_VR.Core.PlayerBehaviours.BodyHaptics.Shockwave
         private bool IsInElevator()
         {
             return m_lastLocState == PlayerLocomotion.PLOC_State.InElevator;
+        }
+
+        public bool AgentActive()
+        {
+            return VRConfig.configUseShockwave.Value && ShockwaveManager.Instance.Ready && ShockwaveManager.Instance.suitConnected();
         }
     }
 }

--- a/GTFO_VR/Core/PlayerBehaviours/BodyHaptics/Shockwave/ShockwaveIntegration.cs
+++ b/GTFO_VR/Core/PlayerBehaviours/BodyHaptics/Shockwave/ShockwaveIntegration.cs
@@ -131,7 +131,7 @@ namespace GTFO_VR.Core.PlayerBehaviours.BodyHaptics.Shockwave
                 "Arm and body reload haptics should have same indices length and delay, or the Task.Delay must be adapted to match both durations");
             int sleepDuration = bodyIndices.Length * bodyPattern.delay;
 
-            while (m_isReloading)
+            while (m_isReloading && AgentActive())
             {
                 ShockwaveEngine.PlayPattern(armPattern);
                 ShockwaveEngine.PlayPattern(bodyPattern);
@@ -324,7 +324,7 @@ namespace GTFO_VR.Core.PlayerBehaviours.BodyHaptics.Shockwave
             };
 
             int i = 0;
-            while (m_isBioScanning)
+            while (m_isBioScanning && AgentActive())
             {
                 HapticIndexPattern pattern = null;
                 switch (i % 4)
@@ -563,7 +563,7 @@ namespace GTFO_VR.Core.PlayerBehaviours.BodyHaptics.Shockwave
 
             const float VERY_LOW_HEALTH = 0.10f;
 
-            while (m_isLowHealth)
+            while (m_isLowHealth && AgentActive())
             {
                 float intensity = 0.2f;
                 int delay = 1000;

--- a/GTFO_VR/Core/VRConfig.cs
+++ b/GTFO_VR/Core/VRConfig.cs
@@ -75,8 +75,8 @@ namespace GTFO_VR.Core
             BindHeader("Input");
             configUseLeftHand = BindBool(file, "Input", "Use left hand as main hand?", false, "If true, all items will appear in the left hand", "Left handed mode");
             configProtube = BindBool(file, "Input", "Enable ProTubeVR support?", true, "If true, will enable ProTubeVR events", "ProtubeVR Support");
-            configUseBhaptics = BindBool(file, "Bhaptics", "Enable bhaptics", true, "If true, bhaptics integration will be enabled", "Bhaptics");
-            configUseShockwave = BindBool(file, "Shockwave", "Enable Shockwave", true, "If true, Shockwave integration will be enabled", "Shockwave");
+            configUseBhaptics = BindBool(file, "Bhaptics", "Enable bhaptics", true, "If true, bhaptics integration will be enabled", "Bhaptics Support");
+            configUseShockwave = BindBool(file, "Shockwave", "Enable Shockwave", true, "If true, Shockwave integration will be enabled", "Shockwave Support");
 
             configIRLCrouch = BindBool(file, "Input", "Crouch in-game when you crouch IRL?", true, "If true, when crouching down below a certain threshold IRL, the in-game character will also crouch", "Crouch on IRL crouch");
             configCrouchHeight = BindInt(file, "Input", "Crouch height in centimeters", 115, 90, 145, "In-game character will be crouching if your head is lower than this height above the playspace", "Crouch height (cm)");

--- a/GTFO_VR/Core/VRConfig.cs
+++ b/GTFO_VR/Core/VRConfig.cs
@@ -23,6 +23,7 @@ namespace GTFO_VR.Core
         internal static ConfigEntry<bool> configUseLaserPointerOnWeapons;
         internal static ConfigEntry<bool> configUseWeaponHaptics;
         internal static ConfigEntry<bool> configUseBhaptics;
+        internal static ConfigEntry<bool> configUseShockwave;
         internal static ConfigEntry<string> configLaserPointerColor;
         internal static ConfigEntry<float> configShootingHapticsStrength;
         internal static ConfigEntry<int> configWeaponRotationOffset;
@@ -75,6 +76,7 @@ namespace GTFO_VR.Core
             configUseLeftHand = BindBool(file, "Input", "Use left hand as main hand?", false, "If true, all items will appear in the left hand", "Left handed mode");
             configProtube = BindBool(file, "Input", "Enable ProTubeVR support?", true, "If true, will enable ProTubeVR events", "ProtubeVR Support");
             configUseBhaptics = BindBool(file, "Bhaptics", "Enable bhaptics", true, "If true, bhaptics integration will be enabled", "Bhaptics");
+            configUseShockwave = BindBool(file, "Shockwave", "Enable Shockwave", true, "If true, Shockwave integration will be enabled", "Shockwave");
 
             configIRLCrouch = BindBool(file, "Input", "Crouch in-game when you crouch IRL?", true, "If true, when crouching down below a certain threshold IRL, the in-game character will also crouch", "Crouch on IRL crouch");
             configCrouchHeight = BindInt(file, "Input", "Crouch height in centimeters", 115, 90, 145, "In-game character will be crouching if your head is lower than this height above the playspace", "Crouch height (cm)");


### PR DESCRIPTION
# What

Adds a new setting for toggling `Shockwave` suit support. It also prevents suit initialization from being performed unless/until enabled, as this can cause issues for some users. 

In addition to checking whether the setting has been enabled, we also check if the suit was successfully initialized and that the suit is connected before performing any of the work involved in submitting the haptic patterns.

An Info log entry was added immediately before the initialization, so that we can easily identify from the logs if another user encounters the same issue and needs to disable `Shockwave` support.

# How
There was no existing setting to toggle Shockwave support, so a new one was added. The setting is monitored and the Shockwave suit will be initialized if the setting is enabled after launching the game.

Both `BodyHapticAgents` have been given a new method for checking whether they should perform any work, `bool AgentActive()`. 
In `ShockwaveIntegration` this checks whether the setting is enabled, was successfully initialized, and is actually connected. 
```csharp
public bool AgentActive()
{
    return VRConfig.configUseShockwave.Value && ShockwaveManager.Instance.Ready && ShockwaveManager.Instance.suitConnected();
}
```

In `BhapticsIntegration` this currently only checks the setting. Any calls that queried the setting directly have been redirected to use `AgentActive()` instead. Ideally this should also check for the presence of a `bHaptics` suit to avoid unnecessary work. 
```csharp
public bool AgentActive()
{
    return VRConfig.configUseBhaptics.Value;
}
```` 

Both agents will continue to update their internal state when disabled, without triggering any haptic patterns. 
`AgentActive()` is also used in a few locations to ensure that while() loops exit when disabled, if they were already active. 

# Considerations

I own neither a bHaptics suit nor a Shockwave suit, so this should ideally be tested by someone who owns them.
 