### PR TITLE
Limit overlay to HMD refresh rate

### DIFF
--- a/GTFO_VR/Core/UI/VR_UI_Overlay.cs
+++ b/GTFO_VR/Core/UI/VR_UI_Overlay.cs
@@ -101,6 +101,10 @@ namespace GTFO_VR.Core.UI
                 }
                 RenderUI();
             }
+
+            // SteamVR_Render will set targetFrameRate to -1 in its Update(), resulting in unconstrainted framerate in overlay.
+            // Each component sets the value when active/rendering, so we can set-and-forget.
+            Application.targetFrameRate = (int)SteamVR.instance.hmd_DisplayFrequency;
         }
 
         internal void CreateRenderTexture()


### PR DESCRIPTION
### What

Limits the framerate to match the HMD display frequency when opening the overlay map/menu.

Previously the framerate was unconstrained, resulting in framerates of 200-400fps until either the GPU or CPU bottlenecks.

The GPU bottlenecking before the CPU is a potential cause of the menu stutter issue.
The menu stutter issue will cause VR and Steam's VR preview to stutter, but the game window is unaffected, which is similar to how things like the OBS compositor chokes when the GPU is overloaded.

### How

What causes the framerate to be unconstrained in the first place is `Application.targetFrameRate` being set to `-1` in `SteamVR_Renderer.Update()` in the `SteamVR Standalone` library: 

```csharp
public class SteamVR_Render : MonoBehaviour
{
    void Update()
    {
        ...
        // Ensure various settings to minimize latency.
        Application.targetFrameRate = -1;
        ...
    }
} 
```
The method returns early when the overlay is open, so it doesn't actually get set until cagedrop. 
Prior to this it will follow the framerate cap in the GTFO display settings.

We update `VR_UI_Overlay.Update()` to do the same thing when it is active, setting it to `SteamVR.instance.hmd_DisplayFrequency` instead of `-1`. 

```csharp
public class VR_UI_Overlay : MonoBehaviour
{
    private void Update()
    {
        ...
        // SteamVR_Render will set targetFrameRate to -1 in its Update(), resulting in unconstrainted framerate in overlay.
        // Each component sets the value when active/rendering, so we can set-and-forget.
        Application.targetFrameRate = (int)SteamVR.instance.hmd_DisplayFrequency;
    }
} 
```
Since each component sets the correct value when active, we don't have to worry about reverting it.
