### PR TITLE
Fix shockwave suit support

### DIFF
--- a/GTFO_VR/Core/PlayerBehaviours/BodyHaptics/Shockwave/Engine/ShockwaveEngine.cs
+++ b/GTFO_VR/Core/PlayerBehaviours/BodyHaptics/Shockwave/Engine/ShockwaveEngine.cs
@@ -154,5 +154,18 @@ namespace GTFO_VR.Core.PlayerBehaviours.BodyHaptics.Shockwave.Engine
 
             return pattern;
         }
+
+        public static bool IsActive()
+        {
+            try
+            {
+                return VRConfig.configUseShockwave.Value && ShockwaveManager.Instance.Ready && ShockwaveManager.Instance.suitConnected();
+            }
+            catch
+            {
+                // The suitConnected() call sometimes throws exceptions every time it's called, ending up in a crash
+                return false;
+            }
+        }
     }
 }

--- a/GTFO_VR/Core/PlayerBehaviours/BodyHaptics/Shockwave/Engine/ShockwaveEngine.cs
+++ b/GTFO_VR/Core/PlayerBehaviours/BodyHaptics/Shockwave/Engine/ShockwaveEngine.cs
@@ -157,15 +157,7 @@ namespace GTFO_VR.Core.PlayerBehaviours.BodyHaptics.Shockwave.Engine
 
         public static bool IsActive()
         {
-            try
-            {
-                return VRConfig.configUseShockwave.Value && ShockwaveManager.Instance.Ready && ShockwaveManager.Instance.suitConnected();
-            }
-            catch
-            {
-                // The suitConnected() call sometimes throws exceptions every time it's called, ending up in a crash
-                return false;
-            }
+            return VRConfig.configUseShockwave.Value && ShockwaveManager.Instance.Ready;
         }
     }
 }

--- a/GTFO_VR/Core/PlayerBehaviours/BodyHaptics/Shockwave/ShockwaveElevatorSequence.cs
+++ b/GTFO_VR/Core/PlayerBehaviours/BodyHaptics/Shockwave/ShockwaveElevatorSequence.cs
@@ -189,7 +189,7 @@ namespace GTFO_VR.Core.PlayerBehaviours.BodyHaptics.Shockwave
 
         public bool AgentActive()
         {
-            return VRConfig.configUseShockwave.Value && ShockwaveManager.Instance.Ready && ShockwaveManager.Instance.suitConnected();
+            return ShockwaveEngine.IsActive();
         }
     }
 }

--- a/GTFO_VR/Core/PlayerBehaviours/BodyHaptics/Shockwave/ShockwaveIntegration.cs
+++ b/GTFO_VR/Core/PlayerBehaviours/BodyHaptics/Shockwave/ShockwaveIntegration.cs
@@ -713,7 +713,7 @@ namespace GTFO_VR.Core.PlayerBehaviours.BodyHaptics.Shockwave
 
         public bool AgentActive()
         {
-            return VRConfig.configUseShockwave.Value && ShockwaveManager.Instance.Ready && ShockwaveManager.Instance.suitConnected();
+            return ShockwaveEngine.IsActive();
         }
 
         public void OnLiquidSplat()

--- a/GTFO_VR/Core/VRConfig.cs
+++ b/GTFO_VR/Core/VRConfig.cs
@@ -76,7 +76,7 @@ namespace GTFO_VR.Core
             configUseLeftHand = BindBool(file, "Input", "Use left hand as main hand?", false, "If true, all items will appear in the left hand", "Left handed mode");
             configProtube = BindBool(file, "Input", "Enable ProTubeVR support?", true, "If true, will enable ProTubeVR events", "ProtubeVR Support");
             configUseBhaptics = BindBool(file, "Bhaptics", "Enable bhaptics", true, "If true, bhaptics integration will be enabled", "Bhaptics Support");
-            configUseShockwave = BindBool(file, "Shockwave", "Enable Shockwave", false, "If true, Shockwave integration will be enabled", "Shockwave Support");
+            configUseShockwave = BindBool(file, "Shockwave", "Enable Shockwave (beta)", false, "If true, Shockwave suit integration will be enabled", "Shockwave Support");
 
             configIRLCrouch = BindBool(file, "Input", "Crouch in-game when you crouch IRL?", true, "If true, when crouching down below a certain threshold IRL, the in-game character will also crouch", "Crouch on IRL crouch");
             configCrouchHeight = BindInt(file, "Input", "Crouch height in centimeters", 115, 90, 145, "In-game character will be crouching if your head is lower than this height above the playspace", "Crouch height (cm)");

--- a/GTFO_VR/Core/VRConfig.cs
+++ b/GTFO_VR/Core/VRConfig.cs
@@ -76,7 +76,7 @@ namespace GTFO_VR.Core
             configUseLeftHand = BindBool(file, "Input", "Use left hand as main hand?", false, "If true, all items will appear in the left hand", "Left handed mode");
             configProtube = BindBool(file, "Input", "Enable ProTubeVR support?", true, "If true, will enable ProTubeVR events", "ProtubeVR Support");
             configUseBhaptics = BindBool(file, "Bhaptics", "Enable bhaptics", true, "If true, bhaptics integration will be enabled", "Bhaptics Support");
-            configUseShockwave = BindBool(file, "Shockwave", "Enable Shockwave", true, "If true, Shockwave integration will be enabled", "Shockwave Support");
+            configUseShockwave = BindBool(file, "Shockwave", "Enable Shockwave", false, "If true, Shockwave integration will be enabled", "Shockwave Support");
 
             configIRLCrouch = BindBool(file, "Input", "Crouch in-game when you crouch IRL?", true, "If true, when crouching down below a certain threshold IRL, the in-game character will also crouch", "Crouch on IRL crouch");
             configCrouchHeight = BindInt(file, "Input", "Crouch height in centimeters", 115, 90, 145, "In-game character will be crouching if your head is lower than this height above the playspace", "Crouch height (cm)");


### PR DESCRIPTION
Fix Shockwave suit integration that was sometimes causing crashes for some players:
- Remove `suitConnected()` call that was sometimes crashing or causing Shockwave suit to not work at all
- Set the "Enable Shockwave" option to disabled by default
- Add "(beta)" text to "Enable Shockwave" option