### PR TITLE
Fix shotguns not firing in weapon direction

### DIFF
--- a/GTFO_VR/Injections/Gameplay/InjectFireFromMuzzle.cs
+++ b/GTFO_VR/Injections/Gameplay/InjectFireFromMuzzle.cs
@@ -6,6 +6,7 @@ namespace GTFO_VR.Injections.Gameplay
 {
     /// <summary>
     /// Makes weapons fire from the muzzle of the weapon instead of the camera.
+    /// TODO: Remove. Base-game logic already does this now, probably reundant.
     /// </summary>
     [HarmonyPatch(typeof(BulletWeapon), nameof(BulletWeapon.Fire))]
     internal class InjectFireFromWeaponMuzzle
@@ -25,6 +26,36 @@ namespace GTFO_VR.Injections.Gameplay
         {
             __instance.Owner.FPSCamera.Position = cachedPosition;
             __instance.Owner.FPSCamera.CameraRayPos = cachedLookPosition;
+        }
+    }
+
+    /// <summary>
+    /// Makes shotgun-typw weapons fire from the muzzle of the weapon instead of the camera.
+    /// FPSCamera itself has an empty transform, and is moved by its parent transforms.
+    /// The transform of FPSCameraRotation sandwiched between the holder and the camera is used for Shotgun pewpew. 
+    /// </summary>
+    [HarmonyPatch(typeof(Shotgun), nameof(Shotgun.Fire))]
+    internal class InjectFireFromShotgunWeaponMuzzle
+    {
+        private static Vector3 cachedCamRotPosition = Vector3.zero;
+        private static Quaternion cachedCamRotRotation = Quaternion.identity;
+
+        private static void Prefix(Shotgun __instance)
+        {
+            Transform camRotation = __instance.Owner.FPSCamera.transform.parent;
+
+            cachedCamRotPosition = camRotation.transform.position;
+            cachedCamRotRotation = camRotation.transform.rotation;
+            camRotation.transform.position = __instance.MuzzleAlign.position;
+            camRotation.transform.rotation = __instance.MuzzleAlign.rotation;
+        }
+
+        private static void Postfix(Shotgun __instance)
+        {
+            Transform camRotation = __instance.Owner.FPSCamera.transform.parent;
+
+            camRotation.position = cachedCamRotPosition;
+            camRotation.rotation = cachedCamRotRotation;
         }
     }
 }


### PR DESCRIPTION
## The problem

Starting with `ALT://R6`, all shotgun-type weapons will fire in the direction the player camera is facing, rather than in the direction the muzzle of the weapon is pointing. 

[broken_shotgun.webm](https://github.com/DSprtn/GTFO_VR_Plugin/assets/8961771/ce09d5bd-924b-4047-ad86-88917c340efb)

This only affects shotgun-type weapons.

In the `InjectFireFromWeaponMuzzle` patch, `BulletWeapon.Fire()` is hooked and the player `FPSCamera` position and direction is changed to that of the weapon's `MuzzleAlign`. At the time of implementation, weapons would fire forwards from the center of the camera.
In more recent versions of the game, shotgun-type weapons have been subclassed into `Shotgun`, with its own `Shotgun.Fire()` implementation, meaning the above patch does not affect it.

The reason this never broke anything is because, up until `ALT://R5`, they had both been changed to use the position and orientation of the weapon `MuzzleAlign`, rather than the camera transform, making the above patch redundant. 

With `Alt://R6`, `Shotgun.Fire()` in particular was heavily modified, and now uses the orientation of the camera again, but not directly.

## The fix

[fixed_shotgun.webm](https://github.com/DSprtn/GTFO_VR_Plugin/assets/8961771/e444f968-0003-4d23-ab17-285b2a396f36)

The player `FPSCamera` itself does not have a local transform. It is nested under a `FPSCameraHolder` and a `FPSCameraRotation` object, which handle translation and rotation respectively.

`Shotgun.Fire()` uses the `FPSCameraRotation` transform to determine where the weapon should fire, so we simply need to change its position and rotation for the duration of the call, and then revert them, similar to what `InjectFireFromWeaponMuzzle` does.

There does not appear to be any direct references to the `FPSCameraRotation` GameObject, but it is the direct parent of `FPSCamera`, making it easily obtainable. 