### PR TITLE
Fix R8 issues

### DIFF
--- a/GTFO_VR/Core/WeaponArchetypeVRData.cs
+++ b/GTFO_VR/Core/WeaponArchetypeVRData.cs
@@ -80,26 +80,38 @@ namespace GTFO_VR.Core
 
                 // Primary
                 { "SHELLING S49", new VRWeaponData(new Vector3(0f, 0f, 0f), false) },
+                { "SHELLING NANO", new VRWeaponData(new Vector3(0f, 0f, 0f), false) },
                 { "BATALDO 3RB", new VRWeaponData(new Vector3(.0f, 0f, 0f), false) },
+                { "RAPTUS TREFFEN 2", new VRWeaponData(new Vector3(.0f, 0f, 0f), false) },
+                { "RAPTUS STEIGRO", new VRWeaponData(new Vector3(.0f, 0f, 0f), false) },
                 { "ACCRAT GOLOK DA", new VRWeaponData(new Vector3(.0f, 0f, -.08f), true) },
                 { "VAN AUKEN LTC5", new VRWeaponData(new Vector3(0f, 0f, -.15f), true) },
                 { "ACCRAT STB", new VRWeaponData(new Vector3(0f, 0f, 0f), true) },
                 { "VAN AUKEN CAB F4", new VRWeaponData(new Vector3(0f, 0f, 0f), true) },
                 { "TR22 HANAWAY", new VRWeaponData(new Vector3(0f, 0f, 0f), true) },
+                { "HANAWAY PSB", new VRWeaponData(new Vector3(0f, 0f, 0f), true) },
                 { "MALATACK LX", new VRWeaponData(new Vector3(0f, 0f, 0f), true) },
+                { "MALATACK CH 4", new VRWeaponData(new Vector3(0f, 0f, 0f), true) },
+                { "DREKKER PRES MOD 556", new VRWeaponData(new Vector3(0f, 0f, 0f), true) },
+                { "BUCKLAND SBS III", new VRWeaponData(new Vector3(0f, 0f, 0f), false) },
                 { "BATALDO J 300", new VRWeaponData(new Vector3(0f, 0f, 0f), true) },
 
                 // Special
                 { "MALATACK HXC", new VRWeaponData(new Vector3(0f, 0f, 0f), true) },
+                { "DREKKER CLR", new VRWeaponData(new Vector3(0f, 0f, 0f), true) },
                 { "BUCKLAND S870", new VRWeaponData(new Vector3(0f, 0f, 0f), true) },
-                { "BUCKLAND XDIST2", new VRWeaponData(new Vector3(0f, 0f, 0f), true) },
                 { "BUCKLAND AF6", new VRWeaponData(new Vector3(0f, 0f, 0f), true) },
-                { "MASTABA R66", new VRWeaponData(new Vector3(0f, 0f, 0f), true) },
+                { "DREKKER INEX DREI", new VRWeaponData(new Vector3(0f, 0f, 0f), true) },
+                { "BUCKLAND XDIST2", new VRWeaponData(new Vector3(0f, 0f, 0f), true) },
+                { "MASTABA R66", new VRWeaponData(new Vector3(0f, 0f, 0f), false) },
                 { "TECHMAN ARBALIST V", new VRWeaponData(new Vector3(0f, 0f, 0f), true) },
                 { "TECHMAN VERUTA XII", new VRWeaponData(new Vector3(0f, 0f, 0f), true) },
-                { "SHELLING ARID 5", new VRWeaponData(new Vector3(0f, 0f, 0f), true) },
+                { "TECHMAN KLAUST 6", new VRWeaponData(new Vector3(0f, 0f, 0f), true) },
+                { "OMNECO EXP1", new VRWeaponData(new Vector3(0f, 0f, 0f), true) },
+                { "SHELLING ARID 5", new VRWeaponData(new Vector3(0f, 0f, 0f), false) },
                 { "DREKKER DEL P1", new VRWeaponData(new Vector3(0f, 0f, 0f), true) },
-                { "KÖNING PR 11", new VRWeaponData(new Vector3(0f, 0f, 0f), true) }
+                { "OMNECO LRG", new VRWeaponData(new Vector3(0f, 0f, 0f), true) },
+                { "BATALDO CUSTOM K330", new VRWeaponData(new Vector3(0f, 0f, 0f), true) },
             };
 
             m_current = weaponDataByPublicName["Default"];

--- a/GTFO_VR/Core/WeaponArchetypeVRData.cs
+++ b/GTFO_VR/Core/WeaponArchetypeVRData.cs
@@ -69,9 +69,19 @@ namespace GTFO_VR.Core
                 { "Default", new VRWeaponData(new Vector3(0f, 0f, 0f), false) },
                 // Melee
                 { "SANTONIAN HDH", new VRWeaponData(new Vector3(0f, -.25f, 0f), Quaternion.Euler(new Vector3(45f, 0, 0)), false) },
+                { "OMNECO MAUL", new VRWeaponData(new Vector3(0f, -.25f, 0f), Quaternion.Euler(new Vector3(45f, 0, 0)), false) },
+                { "KOVAC SLEDGEHAMMER", new VRWeaponData(new Vector3(0f, -.25f, 0f), Quaternion.Euler(new Vector3(45f, 0, 0)), false) },
+                { "SANTONIAN MALLET", new VRWeaponData(new Vector3(0f, -.25f, 0f), Quaternion.Euler(new Vector3(45f, 0, 0)), false) },
+                { "MACO GAVEL", new VRWeaponData(new Vector3(0f, -.25f, 0f), Quaternion.Euler(new Vector3(45f, 0, 0)), false) },
+
                 { "MASTABA FIXED BLADE", new VRWeaponData(new Vector3(0f, -.05f, 0f), Quaternion.Euler(new Vector3(45f, 0, 0)), false) },
+                { "WOX COMPACT", new VRWeaponData(new Vector3(0f, -.05f, 0f), Quaternion.Euler(new Vector3(45f, 0, 0)), false) },
+
                 { "MACO DRILLHEAD", new VRWeaponData(new Vector3(0f, -.3f, 0f), Quaternion.Euler(new Vector3(45f, 0, 0)), false) },
+                { "ISOCO STINGER", new VRWeaponData(new Vector3(0f, -.3f, 0f), Quaternion.Euler(new Vector3(45f, 0, 0)), false) },
+
                 { "KOVAC PEACEKEEPER", new VRWeaponData(new Vector3(0f, -.05f, 0f), Quaternion.Euler(new Vector3(45f, 0, 0)), false) },
+                { "ATTROC TITANIUM", new VRWeaponData(new Vector3(0f, -.05f, 0f), Quaternion.Euler(new Vector3(45f, 0, 0)), false) },
 
                 // Tool
                 { "STALWART FLOW G2", new VRWeaponData(new Vector3(0f, 0f, 0f), false) },

--- a/GTFO_VR/Injections/Gameplay/InjectMuzzleAlignCorrection.cs
+++ b/GTFO_VR/Injections/Gameplay/InjectMuzzleAlignCorrection.cs
@@ -14,7 +14,7 @@ namespace GTFO_VR.Injections.Gameplay
         private static void Postfix(BulletWeapon __instance)
         {
             // Accrat ND6 Heavy SMG
-            if ("ACCRAT ND6".Equals(__instance.PublicName.ToUpper()))
+            if ("ACCRAT ND6".Equals(__instance.PublicName.ToUpper()) || "DREKKER CLR".Equals(__instance.PublicName.ToUpper()))
             {
                 Transform muzzleAlign = __instance.MuzzleAlign;
                 Transform animationRef = muzzleAlign.parent; // This is keyframed with an incorrect rotation, 

--- a/GTFO_VR/Injections/Rendering/InjectFPRendering.cs
+++ b/GTFO_VR/Injections/Rendering/InjectFPRendering.cs
@@ -111,6 +111,17 @@ namespace GTFO_VR.Injections.Rendering
                     continue;
                 }
 
+                GameObject sightGO = m.gameObject;
+
+                // Bataldo Custom K33
+                if (sightGO.name.Equals("Sight_24_picture"))
+                {
+                    // This sight is culled from the wrong direction in VR
+                    // Crosshairs do suggest it is actually being flipped for some reason.
+                    // Aligns correctly when rotated 180
+                    sightGO.transform.localRotation = Quaternion.Euler(0, 180, 0);
+                }
+
                 bool isThermalShaderObject = false;
 
                 foreach (Material mat in m.sharedMaterials)

--- a/GTFO_VR/Injections/Rendering/InjectFPRendering.cs
+++ b/GTFO_VR/Injections/Rendering/InjectFPRendering.cs
@@ -83,7 +83,16 @@ namespace GTFO_VR.Injections.Rendering
 
         private static void fixCenteredCrosshairTexture( Material mat, string textureName, float verticalShift )
         {
-            var texture = mat.GetTexture(textureName).Cast<Texture2D>();
+            var rawTexture = mat.GetTexture(textureName);
+
+            // This apparently gets called multiple times, and sometimes the texture is empty
+            if (rawTexture == null)
+            {
+                return;
+            }
+
+            var texture = rawTexture.Cast<Texture2D>();
+
             string cacheKey = mat.name + textureName;
 
             // Cache textures so we don't generate a million copies


### PR DESCRIPTION
## Fix various issues introduced in R8

### Pistols incorrectly set to two-hand
There was a copy-pasta incident in the past where one of the pistols was incorrectly configured to be two-handed. Turns out this affected some other pistols too, namely the `MASTABA R66 (Revolver)` and the `Shelling Arid 5 (High Caliber Pistol)`. These entries have been corrected, and all remaining weapons added to the list.

### New melee weapons offset
All the new melee weapons use existing archtypes ( sledgehammer, knife, baton ), and have roughly the same shape as existing weapons. However, Archtypes names are only used when positioning the hitboxes, while the positional offset of the weapon is determined by its `VRWeaponData` entry in `WeaponArchtypeVRData.cs`, which is per-weapon. Copy-pasta'd existing entries for new weapons, problem solved.

### Drekker CLR misaligned sight

The `Drekker CLR` suffers from the same misaligned muzzle problem as the `Accrat ND6 Heavy SMG`, and the fix is the same. See https://github.com/DSprtn/GTFO_VR_Plugin/pull/49 for details on that.

### Bataldo Custom K33 missing sight
The sight on this shotgun is only visible when viewed from the front of the gun, as if the normals are inverted and backface culling enabled. I don't see any options in the shader to tweak the culling behavior, so
rotating the holographic portion of the sight 180 is the obvious solution. Doing this the sight is zeroed correctly, and the way the 3 crosshairs aligns suggest this is in fact the correct alignment. Good enough in any case.
![jjk9yzG](https://github.com/DSprtn/GTFO_VR_Plugin/assets/8961771/d671f9f8-b02e-4667-866c-372405b4b172)

### fixCenteredCrosshairTexture NPE
This method is responsible for dealing with the crosshair texture of the `Techman Arbalist`, which needs to be cropped in order to be centered properly. For some reason it gets called multiple times for the same material, and on the first call the texture is empty. Didn't break anything, but return early if texture is null now.
