### PR TITLE
Disappearing nameplates, menu scroll, ZONE button

### DIFF
--- a/GTFO_VR/Core/UI/Terminal/TerminalKeyboardInterface.cs
+++ b/GTFO_VR/Core/UI/Terminal/TerminalKeyboardInterface.cs
@@ -122,7 +122,16 @@ namespace GTFO_VR.Core.UI.Terminal
             // Do terminals outside have these values? ( Yes: Zero_0 it turns out )
             if (m_terminal?.m_terminalItem?.FloorItemLocation != null)
             {
-                return m_terminal.m_terminalItem.FloorItemLocation;
+                string zone = m_terminal.m_terminalItem.FloorItemLocation;
+                // As of R8, the zone provided here will often include a description.
+                // There is always a comma followed by a space before the regular ZONEXXX
+                int lastSpace = zone.LastIndexOf(" ");
+                if (lastSpace > 0 && lastSpace + 1 < zone.Length )  // found and not final string char
+                {
+                    return zone.Substring(lastSpace + 1);
+                }
+
+                return zone;
             }
             else
             {

--- a/GTFO_VR/Core/VR_Input/SteamVR_InputHandler.cs
+++ b/GTFO_VR/Core/VR_Input/SteamVR_InputHandler.cs
@@ -264,15 +264,24 @@ namespace GTFO_VR.Core.VR_Input
             }
             else if (InputAction.MenuScroll.Equals(action))
             {
-                if (m_weaponSwitchLeftAction.GetStateDown(SteamVR_Input_Sources.Any))
+                if (FocusStateEvents.currentState == eFocusState.MainMenu)
                 {
-                    return 1f;
+                    Vector2 axis = m_movementAxisAction.GetAxis(SteamVR_Input_Sources.Any);
+                    return axis.y * 0.01f;
                 }
-                if (m_weaponSwitchRightAction.GetStateDown(SteamVR_Input_Sources.Any) 
-                    || (FocusStateEvents.currentState == eFocusState.FPS_CommunicationDialog && m_openAndSelectComms.GetStateDown(SteamVR_Input_Sources.Any) ) )  // Comms menu navigation
+                else
                 {
-                    return -1f;
+                    if (m_weaponSwitchLeftAction.GetStateDown(SteamVR_Input_Sources.Any))
+                    {
+                        return 1f;
+                    }
+                    if (m_weaponSwitchRightAction.GetStateDown(SteamVR_Input_Sources.Any)
+                        || (FocusStateEvents.currentState == eFocusState.FPS_CommunicationDialog && m_openAndSelectComms.GetStateDown(SteamVR_Input_Sources.Any)))  // Comms menu navigation
+                    {
+                        return -1f;
+                    }
                 }
+
             }
             else if (InputAction.MapZoom.Equals(action))
             {

--- a/GTFO_VR/Injections/UI/InjectNavMarkerWorldSpace.cs
+++ b/GTFO_VR/Injections/UI/InjectNavMarkerWorldSpace.cs
@@ -140,7 +140,7 @@ namespace GTFO_VR.Injections.UI
                     return;
                 }
 
-                if (n != null && n.gameObject.active && n.m_trackingObj != null)
+                if (n != null && n.IsVisible && n.m_trackingObj != null)
                 {
                     Vector3 trackingObjPos = n.m_trackingObj.transform.position;
                     n.transform.position = trackingObjPos;


### PR DESCRIPTION
## What

Fixes various minor-to-moderate bugs:

- Fixes Nameplates disappearing when being snatched or transporting to another dimension
- Fixes the ZONE button in the terminal containing the Zone description 
- Adds the ability to scroll menus using the forward/backwards move input ( previously prev/next weapon buttons )

### Disappearing nameplates

`Dimensions` were introduced with `R6`, and with them the need to toggle `NavMarker` visibility depending on whether or not the player is in the same `dimension` as them.
`NavMarker.UpdateTrackingDimension()` updates in what `dimension` the marker exists, and `NavMarker.OnWarp()` updates whether this `dimension` is the same as the one the Player is in. If true, `NavMarker.UpdateEnabledPerDimensionState()` toggles the `GameObject` if `NavMarker.isVisible` is also true.

Since we completely replace the logic of `NavMarkerLayer.AfterCameraUpdate()` where this originally takes place, this has been broken since the release of R6.
https://github.com/DSprtn/GTFO_VR_Plugin/commit/fd61dce706de701e4d835a2d79003166ea1abe5a adds the missing logic, but a week later https://github.com/DSprtn/GTFO_VR_Plugin/commit/12e205dd6899749c21659777a1b1b86cd9f98a3d incorrectly added a check for `NavMarker.gameObject.active` instead of `NavMarker.isVisible` before processing a marker, resulting in it its dimension never being updated, and its `GameObject` never being re-enabled after being disabled.

tl;dr I fixed and broke it about a week apart. 

### Terminal ZONE button

As of R8, Zones can have elaborate descriptive names, such as `Project Insight Server Farm [1], Zone_245`.
This is reflected in the Zone button in the Terminal interface, extending far beyond its bounds:

![eDUnDS1](https://github.com/DSprtn/GTFO_VR_Plugin/assets/8961771/12c7f40a-7700-45d0-b676-7f1b473a4e21)

We look for the last space in the string, and if present cut off anything before it. When listing anything, you want just the raw `ZONE_XXX` value.

### Menu scroll using forward/backwards

Menu scrolling is currently mapped to `previous/next weapon` buttons. Apart from these jumping very far, occasionally skipping content, they may not even be mapped to anything at all if the player uses the Radial Menu instead.

`Movement forward/backwards` is an input that will always be available, and provides smooth responsive scrolling.

This change only affects the overlay menu, and other uses of weapon prev/next, such as the Comms menu, are unchanged.
