### PR TITLE
implement roomscale movement

### DIFF
--- a/GTFO_VR/Core/PlayerBehaviours/PlayerOrigin.cs
+++ b/GTFO_VR/Core/PlayerBehaviours/PlayerOrigin.cs
@@ -89,6 +89,7 @@ namespace GTFO_VR.Core.PlayerBehaviours
 
         private void HandleOriginShift()
         {
+            m_roomscaleOffset = Vector3.zero;
             UpdateOrigin();
             CenterPlayerToOrigin();
             OnOriginShift?.Invoke();
@@ -123,6 +124,17 @@ namespace GTFO_VR.Core.PlayerBehaviours
             // so the camera ends up in the same position. 
             transform.position += m_roomscaleOffset;
         }
+
+        private Vector3 getTorsoPosition()
+        {
+            Vector3 hmdPos = HMD.Hmd.transform.position;
+            // Player's center will be a bit behind the HMD position, especially if they're leaning forwards.
+            Vector3 hmdForwardFlat = Vector3.Cross(HMD.Hmd.transform.right, new Vector3(0, 1, 0)); // HMD direction on horizontal plane
+            hmdPos += hmdForwardFlat * -0.2f;
+
+            return hmdPos;
+        }
+
 
         public void updateRoomscale()
         {
@@ -171,9 +183,8 @@ namespace GTFO_VR.Core.PlayerBehaviours
             }
             #endif
 
-            // Player's center will be a bit behind the HMD position, especially if they're leaning forwards.
-            Vector3 hmdForwardFlat = Vector3.Cross(HMD.Hmd.transform.right, new Vector3(0,1,0)); // HMD direction on horizontal plane
-            hmdPos += hmdForwardFlat * -0.2f;
+            // Offset to roughly where the player torso would actually be
+            hmdPos = getTorsoPosition();
 
             // Vector from player to HMD
             Vector3 playerHmdOffset = hmdPos - playerPos;
@@ -310,6 +321,9 @@ namespace GTFO_VR.Core.PlayerBehaviours
             pos.y = 0f;
             pos = PlayerRotationOffset * pos;
             m_offsetFromPlayerToHMD = pos;
+            // Apply offset so we center the torso rather than the head.
+            // We use torso position when roomscale moving player, so this need to match.
+            m_roomscaleOffset = HMD.Hmd.transform.position - getTorsoPosition();
         }
 
         private void OnDestroy()

--- a/GTFO_VR/Core/PlayerBehaviours/PlayerOrigin.cs
+++ b/GTFO_VR/Core/PlayerBehaviours/PlayerOrigin.cs
@@ -25,6 +25,8 @@ namespace GTFO_VR.Core.PlayerBehaviours
 
         Quaternion PlayerRotationOffset = Quaternion.identity;
 
+        private bool m_shouldRecenter = true;
+
         private void Awake()
         {
             Log.Info("Origin created");
@@ -55,6 +57,16 @@ namespace GTFO_VR.Core.PlayerBehaviours
         private void Update()
         {
             UpdateOrigin();
+
+            if (m_shouldRecenter)
+            {
+                // When the player respawns from a checkpoint, the player is recreated.
+                // The player should be centerd as part of this process, but performing it
+                // too early ( e.g. in Start() ) will not work, resulting in the player 
+                // being stuck in a wall if they're very far away from their center.
+                m_shouldRecenter = false;
+                CenterPlayerToOrigin();
+            }
         }
 
         private void LateUpdate()

--- a/GTFO_VR/Core/PlayerBehaviours/PlayerOrigin.cs
+++ b/GTFO_VR/Core/PlayerBehaviours/PlayerOrigin.cs
@@ -1,5 +1,6 @@
 ﻿using GTFO_VR.Core.VR_Input;
 using GTFO_VR.Events;
+using GTFO_VR.Util;
 using Player;
 using System;
 using UnityEngine;
@@ -19,6 +20,8 @@ namespace GTFO_VR.Core.PlayerBehaviours
         private LocalPlayerAgent m_agent;
 
         private Vector3 m_offsetFromPlayerToHMD = Vector3.zero;
+
+        private Vector3 m_roomscaleOffset = Vector3.zero;
 
         Quaternion PlayerRotationOffset = Quaternion.identity;
 
@@ -42,6 +45,11 @@ namespace GTFO_VR.Core.PlayerBehaviours
             HMD.SetOrigin(transform);
             DontDestroyOnLoad(gameObject);
             Log.Info("Origin created and set");
+        }
+
+        private void FixedUpdate()
+        {
+            updateRoomscale();
         }
 
         private void Update()
@@ -82,6 +90,7 @@ namespace GTFO_VR.Core.PlayerBehaviours
         private void SetInitialRotationOffset()
         {
             m_offsetFromPlayerToHMD = Vector3.zero;
+            m_roomscaleOffset = Vector3.zero;
             PlayerRotationOffset = Quaternion.Euler(new Vector3(0, -HMD.Hmd.transform.localRotation.eulerAngles.y, 0f));
             UpdateOrigin();
         }
@@ -97,6 +106,178 @@ namespace GTFO_VR.Core.PlayerBehaviours
             transform.position = newPosition - m_offsetFromPlayerToHMD;
             transform.rotation = PlayerRotationOffset;
             transform.position -= CalculateCrouchOffset();
+
+            // Player is moved, and origin is shifted in the opposite direction
+            // so the camera ends up in the same position. 
+            transform.position += m_roomscaleOffset;
+        }
+
+        public void updateRoomscale()
+        {
+            // Calculates vector between HMD and player position, and decides if we can 
+            // move player to HMD without messing anything up.
+            // If we can, player is moved with ManualMoveToWithCollision(), and the origin
+            // is shifted so the player doesn't notice that they moved.
+
+            if (m_agent.PlayerCharacterController == null)
+            {
+                return;
+            }
+
+            switch (m_agent.Locomotion.m_currentStateEnum)
+            {
+                // These are basically the only normal locomotion states
+                // If you're not running and not crouched, you're standing.
+                // that includes walking
+                case PlayerLocomotion.PLOC_State.Stand:
+                case PlayerLocomotion.PLOC_State.Run:
+                case PlayerLocomotion.PLOC_State.Crouch:
+                {
+                    break;
+                }
+
+                default:
+                {
+                    return;
+                }
+            }
+
+            // If a player is teleported, the player model may be far far awy from the
+            // VR origin when this is called, so ensure origin is updated first.
+            UpdateOrigin();
+
+            Vector3 playerPos = m_agent.PlayerCharacterController.SmoothPosition; // Player center
+            Vector3 hmdPos = HMD.Hmd.transform.position; // This takes into account existing offset
+
+            #if DEBUG_GTFO_VR
+            if (VRConfig.configDebugOrigin.Value)
+            {
+                // original HMD position at player height. We shift it backwards a bit below, but still refer to it as HMD.
+                GTFODebugDraw3D.DrawSphere(new Vector3(hmdPos.x, playerPos.y, hmdPos.z), .015f, ColorExt.Green(0.5f), renderOntop: true);
+                // Player position
+                GTFODebugDraw3D.DrawSphere(playerPos, .05f, ColorExt.Red(0.5f));
+            }
+            #endif
+
+            // Player's center will be a bit behind the HMD position, especially if they're leaning forwards.
+            Vector3 hmdForwardFlat = Vector3.Cross(HMD.Hmd.transform.right, new Vector3(0,1,0)); // HMD direction on horizontal plane
+            hmdPos += hmdForwardFlat * -0.2f;
+
+            // Vector from player to HMD
+            Vector3 playerHmdOffset = hmdPos - playerPos;
+            float hmdHeightFromPlayer = playerHmdOffset.y;  // Need this for ground raycast
+            playerHmdOffset.y = 0;
+
+            // Player movement.
+            // This includes gravity, so need to clear that
+            Vector3 playerVelocity = m_agent.PlayerCharacterController.m_lastAttemptedFixedMove;
+            playerVelocity.y = 0;
+
+            // Threshold for player to be moved to HMD location is higher
+            // if player is not moving, to prevent accidental movement.
+            bool playerMoving = playerVelocity.magnitude > 0.01f;
+            float distanceThreshold = playerMoving ? 0.05f : 1f;
+            bool shouldUpdate = playerHmdOffset.magnitude > distanceThreshold;
+
+            if (playerHmdOffset.magnitude > 15.0f)
+            {
+                // Sanity check, move HMD to player if we're impossibly far away.
+                // This shouldn't happen.
+                Log.Error("Roomscale tried to move player by more than 15m!: " + playerHmdOffset.magnitude);
+                CenterPlayerToOrigin();
+                return;
+            }
+
+            #if DEBUG_GTFO_VR
+            if (VRConfig.configDebugOrigin.Value)
+            {
+                // HMD position again, but pushed a bit backwards to it's closer to the person's actual center.
+                GTFODebugDraw3D.DrawSphere(playerPos + playerHmdOffset, .025f, ColorExt.Green(0.5f), renderOntop: true);
+
+                // Cube representing distance at which we will move the player
+                Vector3 thresholdPosition = playerPos + (playerHmdOffset.normalized * distanceThreshold);
+                GTFODebugDraw3D.DrawCube(thresholdPosition, Quaternion.identity, new Vector3(.05f, .05f, .05f), ColorExt.Blue(0.5f), renderOntop: true);
+            }
+            #endif
+
+            if (shouldUpdate)
+            {
+                // Moving the player should ideally never result in them falling off a ledge.
+                // However, we also don't want them to be able to walk in the air.
+                bool validHmdTarget = false;
+                // Raycast donwards from HMD location, and only attempt to move player 
+                // if the drop is less than 0.3m, or HMD more than 1.5m from player
+
+                // We cast from the HMD position down to player position ( feet ) + max fall distance
+                float castDistance = Math.Abs(hmdHeightFromPlayer) + 0.3f;
+                RaycastHit hit;
+                if (Physics.SphereCast(
+                    hmdPos,
+                    .1f,                // size, change to same as character collider
+                    new Vector3(0, -1, 0),// down
+                    out hit,
+                    castDistance,               // distance 
+                    LayerManager.MASK_WORLD,
+                    QueryTriggerInteraction.Ignore))
+                {
+                    // Not much of a drop, go ahead
+                    validHmdTarget = true;
+                }
+                else
+                {
+                    float dropOffCliffThreshold = 1.75f;
+
+                    #if DEBUG_GTFO_VR
+                    if (VRConfig.configDebugOrigin.Value)
+                    {
+                        // Tip of raycast. You will only see this if it didn't hit anything.
+                        Vector3 raycastPosition = hmdPos + new Vector3(0, -castDistance, 0);
+                        GTFODebugDraw3D.DrawSphere(raycastPosition, .025f, ColorExt.Red(0.25f), renderOntop: true);
+
+                        // Marker for 1.75m, where we move even if there's a ledge
+                        Vector3 thresholdPosition = playerPos + (playerHmdOffset.normalized * dropOffCliffThreshold);
+                        GTFODebugDraw3D.DrawCube(thresholdPosition, Quaternion.identity, new Vector3(.05f, .05f, .05f), ColorExt.Blue(0.5f), renderOntop: true);
+                    }
+                    #endif
+
+                    // general, we're good as long as we hit something.
+                    // However, to avoid the player walking on air, we should move them if
+                    // they're more than 1.75m away from 
+                    if (playerHmdOffset.magnitude > dropOffCliffThreshold)
+                    {
+                        validHmdTarget = true;
+                    }
+                }
+
+                if (validHmdTarget)
+                {
+
+                    // Ask game to move player, check how far they actually moved, and use that to
+                    // set that roomscale offset that will shift the origin by the opposite amount.
+                    // This way the player viewpoint stays in the exact same location.
+
+                    // While ManualMoveToWithCollision() effectively teleports the player,
+                    // sleepers are still alerted, as detection is based on the distance the 
+                    // player transform moves, calculated in the respective PLOC states.
+
+                    // ManualMoveToWithCollision() will zero out the delta, so store it first
+                    Vector3 originalMoveDelta = m_agent.PlayerCharacterController.m_moveDelta;
+
+                    Vector3 origPlayerPos = m_agent.PlayerCharacterController.m_smoothPosition;
+                    m_agent.PlayerCharacterController.ManualMoveToWithCollision(playerHmdOffset);
+                    Vector3 newPlayerPos = m_agent.PlayerCharacterController.m_smoothPosition;
+
+                    // Restore original delta
+                    m_agent.PlayerCharacterController.m_moveDelta = originalMoveDelta;
+
+                    Vector3 newOriginOffset = (origPlayerPos - newPlayerPos);
+                    newOriginOffset.y = 0; // Just in case
+
+                    // Add new offset to existing offset
+                    m_roomscaleOffset += newOriginOffset;
+                }
+
+            }
         }
 
         private Vector3 CalculateCrouchOffset()

--- a/GTFO_VR/Core/VRConfig.cs
+++ b/GTFO_VR/Core/VRConfig.cs
@@ -62,6 +62,7 @@ namespace GTFO_VR.Core
 
         private static Dictionary<eCellSettingID, ConfigEntryBase> configBindings = new Dictionary<eCellSettingID, ConfigEntryBase>();
 
+        internal static ConfigEntry<bool> configDebugOrigin;
         internal static ConfigEntry<bool> configDebugShowTwoHHitboxes;
         internal static ConfigEntry<bool> configDebugShowHammerHitbox;
 
@@ -72,6 +73,7 @@ namespace GTFO_VR.Core
         {
 #if DEBUG_GTFO_VR
             BindHeader("DEBUG");
+            configDebugOrigin = BindBool(file, "Debug - If you see this, I screwed up!", "Show Origin debug", false, "Shows origin/roomscale debug visuals", "Show Origin debug");
             configDebugShowTwoHHitboxes = BindBool(file, "Debug - If you see this, I screwed up!", "Show 2H hitboxes", false, "Shows two handed weapon hitboxes", "Show 2H hitboxes");
             configDebugShowHammerHitbox = BindBool(file, "Debug - If you see this, I screwed up!", "Show hammer hitbox", false, "Shows hammer hitbox", "Hammer hitbox debug");
 #endif


### PR DESCRIPTION
### What

Adds limited support for roomscale movement. This is mostly intended to allow you to not think about where your center is, without accidentally waking enemies or allowing players to cheat.
Supporting the use of something like a treadmill where the controller would not be the primary movement input has very different implications, and is not the focus of this PR.

### The problem

The `VR player( HMD )` is parented to the `Player model`, which is in turn moved using `controller input`. If the player steps 1 meter to the right in real life with their head, as far as the game is concerned their player has not moved at all, and moving the `Player model` using the controller leaves the `HMD` in this same offset location relative to the `Player model`.

Since collisions are based on the `Player model` location, this means the player may collide with walls, enemies, or even fall because they did not realize they had moved away from the center of their `Player model`.

Since this is a sneaking game, simply moving the `Player Model` to wherever the VR Player is not sufficient.

### The solution

The basic logic goes as follows:

<details><summary>Player moving using controller and Player to HMD distance >0.05m? Move Player to HMD. </summary>

[roomscale.webm](https://github.com/DSprtn/GTFO_VR_Plugin/assets/8961771/3c7322d3-ef42-4ea7-942b-bc225ee3c5ac)

</details>

<details><summary>Player is standing still and Player to HMD distance > 1m?  Move player to HMD.</summary>

[standing_still.webm](https://github.com/DSprtn/GTFO_VR_Plugin/assets/8961771/458f57a9-e87a-4432-95cb-3fc0d8dbab96)

</details>

<details><summary>Moving player would cause a drop of >0.3m? Do not move player.</summary>

[no_fall.webm](https://github.com/DSprtn/GTFO_VR_Plugin/assets/8961771/3681db3f-28de-4703-be4e-6f9895e06ff3)

</details>

<details><summary>Player to HMD Distance is >1.75m for any reason? Move player.</summary>

[forced_drop.webm](https://github.com/DSprtn/GTFO_VR_Plugin/assets/8961771/b36e2658-97de-4e43-8825-d7ed18e071e6)

</details>

<details><summary>Moving the player will trigger enemies just like normal movement would.</summary>

[alert.webm](https://github.com/DSprtn/GTFO_VR_Plugin/assets/8961771/f15974be-5349-4c98-97c4-b970a0fe6456)

</details>

<details><summary>Movement is handled by the PlayerController which considers collisions, so you cannot move anywhere you would otherwise be unable to.</summary>

[collision.webm](https://github.com/DSprtn/GTFO_VR_Plugin/assets/8961771/85d4696c-7da1-4651-9d94-cb5652d89535)

</details>

<details><summary>While the shift is instant to the Player, it is interpolated for other players. Here the player is moved 1m</summary>

[1m_jump.webm](https://github.com/DSprtn/GTFO_VR_Plugin/assets/8961771/db6a5386-decb-4ba1-ad8a-75e7c8f05113)

</details>

### How

In `PlayerOrigin.updateRoomscale()` we first calculate the distance between the `Player model` and the `HMD` on a horizontal plane.

Depending on their locomotion state, and current velocity, we decide whether they should be moved, adding a `Raycast` downwards from the `HMD` position to check how far it would cause the player to drop.

Once it has been decided we will be moving the `Player model`, we call `PlayerCharacterController.ManualMoveToWithCollision()` with the offset to have it attempt to move the `Player model` to the `HMD`. Depending on obstacles in the level this may end up moving the player a shorter distance than requested.

We store the offset between the original position and the new position of the `Player Model` in `PlayerOrigin.m_roomscaleOffset` for later.

All the above logic is performed in `PlayerOrigin.FixedUpdate()`, so `PlayerOrigin.UpdateOrigin()` is called first, as otherwise the `Player Model` may have been moved far away by teleporting or restarting from a checkpoint, but the `VR Origin` with the `HMD` would not have been moved to it yet.

 `PlayerOrigin.UpdateOrigin()` is called several times per frame to move the `PlayerOrigin ( HMD origin )` to the `Player model` position, as well as apply the rotation offset resulting from smooth/snap turning. Here we simply add `PlayerOrigin.m_roomscaleOffset` to the `PlayerOrigin.Transform`, in addition to all the existing offsets.
 This cancels out the effect of moving the `Player model` to the `HMD` position, resulting in a completely seamless transition. 

As a sanity check, we re-center the player ( move `HMD` to wherever the `Player Model` is ) if the distance is greater than 15m.
Previously, the player would not be re-centered correctly when respawning ( checkpoint or host mitigation), resulting in the HMD being offset from the `player model` by whatever distance they are to the origin of their `VR playsplace`
This has been fixed in https://github.com/DSprtn/GTFO_VR_Plugin/pull/61/commits/8830e369e154107098f6b1eecbbd1a3ed1752f38, but the sanity check will hopefully prevent any similar issues from becoming a problem.

Rather than using the HMD position directly, we calculate a rough `Torso` position by shifting the `HMD` position backwards by 20cm on a horizontal plane. When `PlayerOrigin.HandleOriginShift()` is called as a result of smooth/snap turning, we clear the `PlayerOrigin.m_roomscaleOffset` and initialize it with the vector from the `HMD` to the `Torso`, so it centers you to the same position as the roomscale logic.

### Considerations

Since the player is unable to move more than 1m without triggering movement, using this to cheat would be slower than just moving using the controllers.

It is very common to lean over ledges to get a better shot, and the player may move using the controller while doing this. The 1.75m threshold for causing a fall by moving the player is enough to avoid any accidental falls. Even if they stop the maximum of 1m short of the ledge and walk over to it, they will still be walking completely in thin-air long before being dropped.
I did try keeping track of the last grounded position, and measuring a distance from that instance, but you end up with pretty much the exact same result.

Tested 2-3 hours each by 8 players, and haven't run into any new issues, but any potential gameplay implications should be carefully considered.


