### PR TITLE
Add a Team Status panel to the watch menu

### DIFF
--- a/GTFO_VR/Core/VRConfig.cs
+++ b/GTFO_VR/Core/VRConfig.cs
@@ -10,6 +10,7 @@ namespace GTFO_VR.Core
     {
         internal static ConfigEntry<bool> configUseControllers;
         internal static ConfigEntry<bool> configIRLCrouch;
+        internal static ConfigEntry<bool> configIRLCrouchInvert;
         internal static ConfigEntry<bool> configUseLeftHand;
         internal static ConfigEntry<bool> configUseTwoHanded;
         internal static ConfigEntry<bool> configAlwaysDoubleHanded;
@@ -89,6 +90,7 @@ namespace GTFO_VR.Core
 
             configIRLCrouch = BindBool(file, "Input", "Crouch in-game when you crouch IRL?", true, "If true, when crouching down below a certain threshold IRL, the in-game character will also crouch", "Crouch on IRL crouch");
             configCrouchHeight = BindInt(file, "Input", "Crouch height in centimeters", 115, 90, 145, "In-game character will be crouching if your head is lower than this height above the playspace", "Crouch height (cm)");
+            configIRLCrouchInvert = BindBool(file, "Input", "Invert IRL crouch?", false, "If true, the IRL crouch will be inverted so you crouch while standing, and stand while crouching", "Invert IRL crouch");
             configSmoothSnapTurn = BindBool(file, "Input", "Use smooth turning?", false, "If true, will use smooth turn instead of snap turn", "Smooth turn");
             configSnapTurnAmount = BindInt(file, "Input", "Snap turn angle", 60, 0, 180, "The amount of degrees to turn on a snap turn", "Snap turn angle");            
             configSmoothTurnSpeed = BindInt(file, "Input", "Smooth turn speed", 90, 0, 180, "The amount of degrees to turn per second at full speed", "Smooth turn speed (degrees/s)");

--- a/GTFO_VR/Core/VRConfig.cs
+++ b/GTFO_VR/Core/VRConfig.cs
@@ -1,4 +1,4 @@
-﻿using BepInEx.Configuration;
+using BepInEx.Configuration;
 using CellMenu;
 using Il2CppInterop.Runtime.InteropTypes.Arrays;
 using System;
@@ -10,7 +10,6 @@ namespace GTFO_VR.Core
     {
         internal static ConfigEntry<bool> configUseControllers;
         internal static ConfigEntry<bool> configIRLCrouch;
-        internal static ConfigEntry<bool> configIRLCrouchInvert;
         internal static ConfigEntry<bool> configUseLeftHand;
         internal static ConfigEntry<bool> configUseTwoHanded;
         internal static ConfigEntry<bool> configAlwaysDoubleHanded;
@@ -90,7 +89,6 @@ namespace GTFO_VR.Core
 
             configIRLCrouch = BindBool(file, "Input", "Crouch in-game when you crouch IRL?", true, "If true, when crouching down below a certain threshold IRL, the in-game character will also crouch", "Crouch on IRL crouch");
             configCrouchHeight = BindInt(file, "Input", "Crouch height in centimeters", 115, 90, 145, "In-game character will be crouching if your head is lower than this height above the playspace", "Crouch height (cm)");
-            configIRLCrouchInvert = BindBool(file, "Input", "Invert IRL crouch?", false, "If true, the IRL crouch will be inverted so you crouch while standing, and stand while crouching", "Invert IRL crouch");
             configSmoothSnapTurn = BindBool(file, "Input", "Use smooth turning?", false, "If true, will use smooth turn instead of snap turn", "Smooth turn");
             configSnapTurnAmount = BindInt(file, "Input", "Snap turn angle", 60, 0, 180, "The amount of degrees to turn on a snap turn", "Snap turn angle");            
             configSmoothTurnSpeed = BindInt(file, "Input", "Smooth turn speed", 90, 0, 180, "The amount of degrees to turn per second at full speed", "Smooth turn speed (degrees/s)");

--- a/GTFO_VR/Core/VR_Input/SteamVR_InputHandler.cs
+++ b/GTFO_VR/Core/VR_Input/SteamVR_InputHandler.cs
@@ -108,7 +108,7 @@ namespace GTFO_VR.Core.VR_Input
             SteamVR_Action_Boolean boolActionMapping = GetBoolActionMapping(action);
             if (IsIRLCrouchValid(action))
             {
-                return (boolActionMapping != null && boolActionMapping.GetStateDown(SteamVR_Input_Sources.Any)) || HMD.Hmd.transform.localPosition.y + VRConfig.configFloorOffset.Value / 100f < VRConfig.configCrouchHeight.Value / 100f;
+                return (boolActionMapping != null && boolActionMapping.GetStateDown(SteamVR_Input_Sources.Any)) || (VRConfig.configIRLCrouchInvert.Value ? HMD.Hmd.transform.localPosition.y + VRConfig.configFloorOffset.Value / 100f >= VRConfig.configCrouchHeight.Value / 100f : HMD.Hmd.transform.localPosition.y + VRConfig.configFloorOffset.Value / 100f < VRConfig.configCrouchHeight.Value / 100f);
             }
 
             if (action.Equals(InputAction.TerminalExit) && VRKeyboard.KeyboardClosedThisFrame)
@@ -154,7 +154,7 @@ namespace GTFO_VR.Core.VR_Input
             SteamVR_Action_Boolean boolActionMapping = SteamVR_InputHandler.GetBoolActionMapping(action);
             if (IsIRLCrouchValid(action))
             {
-                return (boolActionMapping != null && boolActionMapping.GetState(SteamVR_Input_Sources.Any)) || HMD.Hmd.transform.localPosition.y + VRConfig.configFloorOffset.Value / 100f < VRConfig.configCrouchHeight.Value / 100f;
+                return (boolActionMapping != null && boolActionMapping.GetState(SteamVR_Input_Sources.Any)) || (VRConfig.configIRLCrouchInvert.Value ? HMD.Hmd.transform.localPosition.y + VRConfig.configFloorOffset.Value / 100f >= VRConfig.configCrouchHeight.Value / 100f : HMD.Hmd.transform.localPosition.y + VRConfig.configFloorOffset.Value / 100f < VRConfig.configCrouchHeight.Value / 100f);
             }
             return boolActionMapping != null && boolActionMapping.GetState(SteamVR_Input_Sources.Any);
         }
@@ -169,7 +169,7 @@ namespace GTFO_VR.Core.VR_Input
             SteamVR_Action_Boolean boolActionMapping = GetBoolActionMapping(action);
             if (IsIRLCrouchValid(action))
             {
-                return boolActionMapping != null && !boolActionMapping.GetStateDown(SteamVR_Input_Sources.Any) || !boolActionMapping.GetState(SteamVR_Input_Sources.Any) && (boolActionMapping.GetStateUp(SteamVR_Input_Sources.Any) || (HMD.Hmd.transform.localPosition.y + VRConfig.configFloorOffset.Value > VRConfig.configCrouchHeight.Value / 100f));
+                return boolActionMapping != null && !boolActionMapping.GetStateDown(SteamVR_Input_Sources.Any) || !boolActionMapping.GetState(SteamVR_Input_Sources.Any) && (boolActionMapping.GetStateUp(SteamVR_Input_Sources.Any) || (VRConfig.configIRLCrouchInvert.Value ? HMD.Hmd.transform.localPosition.y + VRConfig.configFloorOffset.Value / 100f <= VRConfig.configCrouchHeight.Value / 100f : HMD.Hmd.transform.localPosition.y + VRConfig.configFloorOffset.Value / 100f > VRConfig.configCrouchHeight.Value / 100f));
             }
             return boolActionMapping != null && boolActionMapping.GetStateUp(SteamVR_Input_Sources.Any);
         }

--- a/GTFO_VR/Core/VR_Input/SteamVR_InputHandler.cs
+++ b/GTFO_VR/Core/VR_Input/SteamVR_InputHandler.cs
@@ -1,4 +1,4 @@
-﻿using GTFO_VR.Events;
+using GTFO_VR.Events;
 using GTFO_VR.UI;
 using System.Collections.Generic;
 using UnityEngine;
@@ -108,7 +108,7 @@ namespace GTFO_VR.Core.VR_Input
             SteamVR_Action_Boolean boolActionMapping = GetBoolActionMapping(action);
             if (IsIRLCrouchValid(action))
             {
-                return (boolActionMapping != null && boolActionMapping.GetStateDown(SteamVR_Input_Sources.Any)) || (VRConfig.configIRLCrouchInvert.Value ? HMD.Hmd.transform.localPosition.y + VRConfig.configFloorOffset.Value / 100f >= VRConfig.configCrouchHeight.Value / 100f : HMD.Hmd.transform.localPosition.y + VRConfig.configFloorOffset.Value / 100f < VRConfig.configCrouchHeight.Value / 100f);
+                return (boolActionMapping != null && boolActionMapping.GetStateDown(SteamVR_Input_Sources.Any)) || HMD.Hmd.transform.localPosition.y + VRConfig.configFloorOffset.Value / 100f < VRConfig.configCrouchHeight.Value / 100f;
             }
 
             if (action.Equals(InputAction.TerminalExit) && VRKeyboard.KeyboardClosedThisFrame)
@@ -154,7 +154,7 @@ namespace GTFO_VR.Core.VR_Input
             SteamVR_Action_Boolean boolActionMapping = SteamVR_InputHandler.GetBoolActionMapping(action);
             if (IsIRLCrouchValid(action))
             {
-                return (boolActionMapping != null && boolActionMapping.GetState(SteamVR_Input_Sources.Any)) || (VRConfig.configIRLCrouchInvert.Value ? HMD.Hmd.transform.localPosition.y + VRConfig.configFloorOffset.Value / 100f >= VRConfig.configCrouchHeight.Value / 100f : HMD.Hmd.transform.localPosition.y + VRConfig.configFloorOffset.Value / 100f < VRConfig.configCrouchHeight.Value / 100f);
+                return (boolActionMapping != null && boolActionMapping.GetState(SteamVR_Input_Sources.Any)) || HMD.Hmd.transform.localPosition.y + VRConfig.configFloorOffset.Value / 100f < VRConfig.configCrouchHeight.Value / 100f;
             }
             return boolActionMapping != null && boolActionMapping.GetState(SteamVR_Input_Sources.Any);
         }
@@ -169,7 +169,7 @@ namespace GTFO_VR.Core.VR_Input
             SteamVR_Action_Boolean boolActionMapping = GetBoolActionMapping(action);
             if (IsIRLCrouchValid(action))
             {
-                return boolActionMapping != null && !boolActionMapping.GetStateDown(SteamVR_Input_Sources.Any) || !boolActionMapping.GetState(SteamVR_Input_Sources.Any) && (boolActionMapping.GetStateUp(SteamVR_Input_Sources.Any) || (VRConfig.configIRLCrouchInvert.Value ? HMD.Hmd.transform.localPosition.y + VRConfig.configFloorOffset.Value / 100f <= VRConfig.configCrouchHeight.Value / 100f : HMD.Hmd.transform.localPosition.y + VRConfig.configFloorOffset.Value / 100f > VRConfig.configCrouchHeight.Value / 100f));
+                return boolActionMapping != null && !boolActionMapping.GetStateDown(SteamVR_Input_Sources.Any) || !boolActionMapping.GetState(SteamVR_Input_Sources.Any) && (boolActionMapping.GetStateUp(SteamVR_Input_Sources.Any) || (HMD.Hmd.transform.localPosition.y + VRConfig.configFloorOffset.Value > VRConfig.configCrouchHeight.Value / 100f));
             }
             return boolActionMapping != null && boolActionMapping.GetStateUp(SteamVR_Input_Sources.Any);
         }


### PR DESCRIPTION
Here is my attempt at adding a Team Status panel to the watch menu. I know some things aren't quite done the 'best' or most ideal way and have used a few workarounds to get this working, it does work in the current state but needs some cleaning up. For example I'm not sure if I used coroutines properly, and I've used a few other workarounds for sentry gun names and player colors. I also re-used the WardenObjective object and cloned it's properties to get the text to fit on the watch correctly, and also re-used the hacking tool icon for now as a placeholder icon. All-in-all, I'm happy with how it turned out and think this would be a great addition to the main mod.

Here are my notes about changes made for the Team Status feature:
- Added a new state for 'Status' in WatchState

- Added an entry in SetupRadialMenu() for status display, re-used the 'hacking tool' icon for now

- Added TMP for m_statusDisplay, which is used in SetupStatusDisplay()
  - NOTE: For this I cloned 'WardenObjective' properties as I couldn't figure out how to get the text to fit on the watch face otherwise, so this will need improving but works for now.

- Added IEnumerator StatusUpdater() to update status while screen is active, refresh rate 250ms
  - NOTE: Not sure this is done correctly, but it seems to work okay. This may need changing / improvement.

- Added a dictionary for lookup of 'tool types' to display sentry type (Burst, Auto, etc)
  - NOTE: This is also a workaround, I found using 'ArchetypeName' wasn't specific enough for sentry gun so I used 'PublicName' and then created a dictionary to map publicname to what I wanted to display. This info must be available somewhere but I just couldn't find it in UnityExplorer / dnSpy so I made this workaround.

- Added a mapper for name colors to use based on slot index, similar to above I would prefer to pull the actual player name colors but this was a quick workaround just to get things working.

- Added helper routines for returning a text color for HP / ammo / infection based on percentage

- Added RefreshStatusDisplay() which loops through player backpack to get inventory info, and Dam_PlayerDamageBase to get HP and infection % and builds a string to update the status display

- Added a new case in SwitchState() to toggle status display, as well as a check to stop the status updater if it's not the active menu
 - Added ToggleStatusRendering()

- Added check in OnDestroy() to make sure the status updater isn't running

Also, I had reverted the changes for the Invert IRL Crouch feature - I wasn't sure if that's something most would use and had mostly made it per request of a user on Discord so wasn't intending to merge those. I did post the changes on the Discord in .diff files though.